### PR TITLE
Fields filtering support via query param

### DIFF
--- a/modules/container/src/main/java/org/projectodd/restafari/container/DirectConnector.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/DirectConnector.java
@@ -40,7 +40,9 @@ public class DirectConnector {
     }
 
     public void create(String path, ResourceState state, Consumer<ResourceResponse> handler) {
-        ResourceRequest request = new ResourceRequest(ResourceRequest.RequestType.CREATE, new ResourcePath(path), ResourceParams.NONE, "ignored", null, state);
+        ResourceRequest request = new ResourceRequest.Builder(ResourceRequest.RequestType.CREATE, new ResourcePath(path))
+                .resourceState(state)
+                .build();
         this.handlers.put(request, handler);
         this.channel.writeInbound(request);
     }
@@ -62,7 +64,8 @@ public class DirectConnector {
     }
 
     public void read(String path, Consumer<ResourceResponse> handler) {
-        ResourceRequest request = new ResourceRequest(ResourceRequest.RequestType.READ, new ResourcePath(path), ResourceParams.NONE, "ignored", null);
+        ResourceRequest request = new ResourceRequest.Builder(ResourceRequest.RequestType.READ, new ResourcePath(path))
+                .build();
         this.handlers.put(request, handler);
         this.channel.writeInbound(request);
     }
@@ -91,7 +94,9 @@ public class DirectConnector {
     }
 
     public void update(String path, ResourceState state, Consumer<ResourceResponse> handler) {
-        ResourceRequest request = new ResourceRequest(ResourceRequest.RequestType.UPDATE, new ResourcePath(path), ResourceParams.NONE, "ignored", null, state);
+        ResourceRequest request = new ResourceRequest.Builder(ResourceRequest.RequestType.UPDATE, new ResourcePath(path))
+                .resourceState(state)
+                .build();
         this.handlers.put(request, handler);
         this.channel.writeInbound(request);
     }
@@ -113,7 +118,8 @@ public class DirectConnector {
     }
 
     public void delete(String path, Consumer<ResourceResponse> handler) {
-        ResourceRequest request = new ResourceRequest(ResourceRequest.RequestType.DELETE, new ResourcePath(path), ResourceParams.NONE, "ignored", null);
+        ResourceRequest request = new ResourceRequest.Builder(ResourceRequest.RequestType.DELETE, new ResourcePath(path))
+                .build();
         this.handlers.put(request, handler);
         this.channel.writeInbound(request);
     }

--- a/modules/container/src/main/java/org/projectodd/restafari/container/ResourceRequest.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/ResourceRequest.java
@@ -1,6 +1,7 @@
 package org.projectodd.restafari.container;
 
 import org.projectodd.restafari.spi.Pagination;
+import org.projectodd.restafari.spi.ReturnFields;
 import org.projectodd.restafari.spi.state.ResourceState;
 
 /**
@@ -15,32 +16,15 @@ public class ResourceRequest {
         DELETE,
     }
 
-    public ResourceRequest(RequestType requestType, ResourcePath resourcePath, ResourceParams params, String mimeType, String authorizationToken) {
-        this.requestType = requestType;
-        this.resourcePath = resourcePath;
-        this.mimeType = mimeType;
-        this.authorizationToken = authorizationToken;
-        this.params = params;
-        this.pagination = Pagination.NONE;
-    }
-
-    public ResourceRequest(RequestType requestType, ResourcePath resourcePath, ResourceParams params, String mimeType, String authorizationToken, Pagination pagination) {
-        this.requestType = requestType;
-        this.resourcePath = resourcePath;
-        this.mimeType = mimeType;
-        this.authorizationToken = authorizationToken;
-        this.params = params;
-        this.pagination = pagination != null ? pagination : Pagination.NONE;
-    }
-
-    public ResourceRequest(RequestType requestType, ResourcePath resourcePath, ResourceParams params, String mimeType, String authorizationToken, ResourceState state) {
-        this.requestType = requestType;
-        this.resourcePath = resourcePath;
-        this.mimeType = mimeType;
-        this.authorizationToken = authorizationToken;
-        this.params = params;
-        this.state = state;
-        this.pagination = Pagination.NONE;
+    private ResourceRequest(RequestType type, ResourcePath path) {
+        if (type == null) {
+            throw new IllegalArgumentException("requestType is null");
+        }
+        if (path == null) {
+            throw new IllegalArgumentException("resourcePath is null");
+        }
+        this.requestType = type;
+        this.resourcePath = path;
     }
 
     public RequestType requestType() {
@@ -71,6 +55,10 @@ public class ResourceRequest {
         return this.authorizationToken;
     }
 
+    public ReturnFields returnFields() {
+        return this.returnFields;
+    }
+
     public String toString() {
         return "[ResourceRequest: type=" + this.requestType() + "; path=" + this.resourcePath + "]";
     }
@@ -82,4 +70,61 @@ public class ResourceRequest {
     private Pagination pagination;
     private ResourceState state;
     private String authorizationToken;
+    private ReturnFields returnFields;
+
+
+    public static class Builder {
+
+        private ResourceRequest obj;
+
+        public Builder(RequestType type, ResourcePath path) {
+            obj = new ResourceRequest(type, path);
+        }
+
+        public Builder resourceParams(ResourceParams params) {
+            obj.params = params;
+            return this;
+        }
+
+        public Builder mimeType(String mimeType) {
+            obj.mimeType = mimeType;
+            return this;
+        }
+
+        public Builder pagination(Pagination pagination) {
+            obj.pagination = pagination;
+            return this;
+        }
+
+        public Builder resourceState(ResourceState state) {
+            obj.state = state;
+            return this;
+        }
+
+        public Builder returnFields(ReturnFields fields) {
+            obj.returnFields = fields;
+            return this;
+        }
+
+        public Builder authorizationToken(String authToken) {
+            obj.authorizationToken = authToken;
+            return this;
+        }
+
+        public ResourceRequest build() {
+            if (obj.mimeType == null) {
+                obj.mimeType = "ignored";
+            }
+
+            if (obj.pagination == null) {
+                obj.pagination = Pagination.NONE;
+            }
+
+            if (obj.params == null) {
+                obj.params = ResourceParams.NONE;
+            }
+
+            return obj;
+        }
+    }
 }

--- a/modules/container/src/main/java/org/projectodd/restafari/container/ReturnFieldsImpl.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/ReturnFieldsImpl.java
@@ -1,0 +1,140 @@
+package org.projectodd.restafari.container;
+
+import org.projectodd.restafari.spi.ReturnFields;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+
+/**
+ * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
+ */
+public class ReturnFieldsImpl implements ReturnFields {
+
+    private HashMap<String, ReturnFields> fields = new LinkedHashMap<>();
+
+
+    private static enum XpctState {
+        xpctIdentCommaOpen,
+        xpctIdent,
+        xpctComma,
+        xpctAnything
+    }
+
+    private static enum FieldState {
+        start,
+        name,
+        end
+    }
+
+    private ReturnFieldsImpl() {
+    }
+
+    public ReturnFieldsImpl(String spec) {
+
+        if (spec == null || spec.trim().length() == 0) {
+            throw new IllegalArgumentException("Fields spec is null or empty!");
+        }
+        // parse the spec, building up the tree for nested children
+        char [] buf = spec.toCharArray();
+        StringBuilder token = new StringBuilder(buf.length);
+
+        // stack for handling depth
+        LinkedList<HashMap<String, ReturnFields>> specs = new LinkedList<>();
+        specs.add(fields);
+
+        // parser state
+        FieldState fldState = FieldState.start;
+        XpctState state = XpctState.xpctIdent;
+
+        int i;
+        for (i = 0; i < buf.length; i++) {
+            char c = buf[i];
+
+            if (c == ',') {
+                if (state == XpctState.xpctIdent) {
+                    error(spec, i);
+                }
+                if (fldState == FieldState.name) {
+                    specs.getLast().put(token.toString(), null);
+                    token.setLength(0);
+                }
+                state = XpctState.xpctIdent;
+                fldState = FieldState.start;
+            } else if (c == '(') {
+                if (state != XpctState.xpctIdentCommaOpen && state != XpctState.xpctAnything) {
+                    error(spec, i);
+                }
+                ReturnFieldsImpl sub = new ReturnFieldsImpl();
+                specs.getLast().put(token.toString(), sub);
+                specs.add(sub.fields);
+                token.setLength(0);
+
+                state = XpctState.xpctIdent;
+                fldState = FieldState.start;
+            } else if (c == ')') {
+                if (state != XpctState.xpctAnything) {
+                    error(spec, i);
+                }
+                if (fldState == FieldState.name) {
+                    specs.getLast().put(token.toString(), null);
+                    token.setLength(0);
+                }
+                specs.removeLast();
+
+                fldState = FieldState.end;
+                state = specs.size() > 1 ? XpctState.xpctAnything : XpctState.xpctComma;
+            } else {
+                token.append(c);
+                if (fldState == FieldState.start) {
+                    fldState = FieldState.name;
+                    state = specs.size() > 1 ? XpctState.xpctAnything : XpctState.xpctIdentCommaOpen;
+                }
+            }
+        }
+
+        if (specs.size() > 1) {
+            error(spec, i);
+        }
+        if (token.length() > 0) {
+            specs.getLast().put(token.toString(), null);
+        } else if (state != XpctState.xpctAnything) {
+            error(spec, i);
+        }
+    }
+
+    private void error(String spec, int i) {
+        throw new RuntimeException("Invalid fields specification at position " + i + ": " + spec);
+    }
+
+    @Override
+    public ReturnFields child(String field) {
+        return fields.get(field);
+    }
+
+    @Override
+    public boolean included(String... pathSegments) {
+
+        if (pathSegments == null || pathSegments.length == 0) {
+            throw new IllegalArgumentException("No path specified!");
+        }
+        ReturnFieldsImpl current = this;
+
+        for (String path: pathSegments) {
+            if (current == null) {
+                return false;
+            }
+            if (!current.fields.containsKey(path)) {
+                return false;
+            }
+            current = (ReturnFieldsImpl) current.fields.get(path);
+        }
+        return true;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return fields.keySet().iterator();
+    }
+}

--- a/modules/container/src/test/java/org/projectodd/restafari/container/FilteredObjectResourceState.java
+++ b/modules/container/src/test/java/org/projectodd/restafari/container/FilteredObjectResourceState.java
@@ -1,0 +1,79 @@
+package org.projectodd.restafari.container;
+
+import org.projectodd.restafari.container.codec.DefaultPropertyResourceState;
+import org.projectodd.restafari.spi.ReturnFields;
+import org.projectodd.restafari.spi.state.ObjectResourceState;
+import org.projectodd.restafari.spi.state.PropertyResourceState;
+
+import java.util.stream.Stream;
+
+/**
+ * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
+ */
+public class FilteredObjectResourceState implements ObjectResourceState {
+
+    private final ObjectResourceState delegate;
+    private final ReturnFields filter;
+
+    public FilteredObjectResourceState(ObjectResourceState delegate, ReturnFields filter) {
+        this.delegate = delegate;
+        this.filter = filter;
+    }
+
+    @Override
+    public void addProperty(String name, Object value) {
+        delegate.addProperty(name, value);
+    }
+
+    @Override
+    public Object getProperty(String name) {
+        if (filter != null && !filter.included(name)) {
+            return null;
+        }
+
+        Object val = delegate.getProperty(name);
+        if (val == null) {
+            return null;
+        }
+
+        ReturnFields childFilter = filter.child(name);
+        if (childFilter != null && val instanceof ObjectResourceState) {
+            val = new FilteredObjectResourceState((ObjectResourceState) val, childFilter);
+        }
+        return val;
+    }
+
+    @Override
+    public Stream<? extends PropertyResourceState> members() {
+        Stream<? extends PropertyResourceState> stream = delegate.members();
+        stream = stream.flatMap((o) -> {
+            if (filter != null && !filter.included(o.id())) {
+                return null;
+            }
+
+            Object val = o.value();
+            if (val == null) {
+                return Stream.of(o);
+            }
+
+            ReturnFields childFilter = filter.child(o.id());
+            if (childFilter != null && val instanceof ObjectResourceState) {
+                val = new FilteredObjectResourceState((ObjectResourceState) val, childFilter);
+                return Stream.of(new DefaultPropertyResourceState(o.id(), val));
+            }
+            return Stream.of(o);
+        });
+
+        return stream;
+    }
+
+    @Override
+    public String id() {
+        return delegate.id();
+    }
+
+    @Override
+    public void id(String id) {
+        delegate.id(id);
+    }
+}

--- a/modules/container/src/test/java/org/projectodd/restafari/container/ReturnFieldsTest.java
+++ b/modules/container/src/test/java/org/projectodd/restafari/container/ReturnFieldsTest.java
@@ -1,0 +1,96 @@
+package org.projectodd.restafari.container;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.projectodd.restafari.spi.ReturnFields;
+
+/**
+ * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
+ */
+public class ReturnFieldsTest {
+
+    @Test
+    public void testBasic() {
+        String spec = "field1,field2,field3";
+        ReturnFieldsImpl fspec = new ReturnFieldsImpl(spec);
+
+        StringBuilder val = new StringBuilder();
+        for (String field: fspec) {
+            if (val.length() > 0)
+                val.append(',');
+            val.append(field);
+        }
+        Assert.assertEquals(spec, val.toString());
+
+        // check catching errors
+
+        String [] specs = {
+            "",
+            null,
+            ",",
+            "field1,",
+            ",field2"
+        };
+
+        for (String filter: specs) {
+            try {
+                fspec = new ReturnFieldsImpl(filter);
+                Assert.fail("Parsing of fields spec should have failed! : " + filter);
+            } catch (Exception e) {
+                //e.printStackTrace();
+            }
+        }
+    }
+
+
+    @Test
+    public void testNested() {
+        String spec = "field1,field2(sub1,sub2(subsub1)),field3";
+        ReturnFieldsImpl fspec = new ReturnFieldsImpl(spec);
+
+        String val = traverse(fspec);
+        Assert.assertEquals(spec, val.toString());
+
+
+        // check catching errors
+
+        String [] specs = {
+            "(",
+            ")",
+            "field1,(",
+            "field1,)",
+            "field1,field2(",
+            "field1,field2)",
+            "field1,field2()",
+            "field1,field2(sub1)(",
+            "field1,field2(sub1))",
+            "field1,field2(sub1),"
+        };
+
+        for (String filter: specs) {
+            try {
+                fspec = new ReturnFieldsImpl(filter);
+                Assert.fail("Parsing of fields spec should have failed! : " + filter);
+            } catch (Exception e) {
+                //e.printStackTrace();
+            }
+        }
+    }
+
+    private String traverse(ReturnFields fspec) {
+        StringBuilder buf = new StringBuilder();
+        for (String field: fspec) {
+            if (buf.length() > 0)
+                buf.append(',');
+            buf.append(field);
+
+            ReturnFields cspec = fspec.child(field);
+            if (cspec != null) {
+                buf.append('(');
+                buf.append(traverse(cspec));
+                buf.append(')');
+            }
+        }
+        return buf.toString();
+    }
+}

--- a/modules/container/src/test/java/org/projectodd/restafari/container/auth/AuthorizationServiceTest.java
+++ b/modules/container/src/test/java/org/projectodd/restafari/container/auth/AuthorizationServiceTest.java
@@ -67,7 +67,7 @@ public class AuthorizationServiceTest {
 
     private AuthorizationRequestContext createAuthRequestContext(String uri, ResourceRequest.RequestType reqType, String[] realmRoles, String[] appRoles) {
         ResourcePath resPath = new ResourcePath(uri);
-        ResourceRequest req = new ResourceRequest(reqType, resPath, ResourceParams.NONE, null, null);
+        ResourceRequest req = new ResourceRequest.Builder(reqType, resPath).build();
 
         Map<String, String[]> appRolesMap = new HashMap<>();
         appRolesMap.put("authTest", appRoles);

--- a/modules/spi/src/main/java/org/projectodd/restafari/spi/ReturnFields.java
+++ b/modules/spi/src/main/java/org/projectodd/restafari/spi/ReturnFields.java
@@ -1,0 +1,36 @@
+package org.projectodd.restafari.spi;
+
+import java.util.Iterator;
+
+/**
+ * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
+ */
+public interface ReturnFields extends Iterable<String> {
+
+    /**
+     * Get ReturnFields for a child field of JSONObject type.
+     *
+     * For basic-typed fields this always returns null. Use included() for those.
+     *
+     * @return ReturnFields for a child field
+     */
+    ReturnFields child(String field);
+
+    /**
+     * Check to see if the field should be included in JSON response.
+     *
+     * The check can be performed for any level of depth relative to current nesting level, by specifying multiple path segments.
+     *
+     * @return true if the specified path should be part of JSON response or not
+     */
+    boolean included(String... pathSegments);
+
+    /**
+     * Iterate over child fields to be included in response.
+     *
+     * To get nested field specifier use child(name) passing the field name this iterator returns.
+     *
+     * @return iterator over child fields to be included in response.
+     */
+    Iterator<String> iterator();
+}


### PR DESCRIPTION
Query parameter 'fields' is used for specifying fields to be included. 

To implement a working field filtering, we need newly introduced ReturnFields object to be propagated to ContainerResource or ObjectResource.

So now we have Pagination, ReturnFields, ResourceParams, and I can image we would get Sorting soon.

All these have to be somehow propagated to ContainerResource.read / ContainerResource.readContent.

I also refactored ResourceRequest construction using Builder pattern to make it more readable. 
