### PR TITLE
Error handling - added default handling for uncaught exception in Container.read()

### DIFF
--- a/modules/container/src/main/java/org/projectodd/restafari/container/DefaultContainer.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/DefaultContainer.java
@@ -67,17 +67,22 @@ public class DefaultContainer implements Container, CollectionResource {
 
     @Override
     public void read(String id, Responder responder) {
-        if ( id == null ) {
-            responder.resourceRead( this );
-            return;
-        }
+        try {
+            if ( id == null ) {
+                responder.resourceRead( this );
+                return;
+            }
 
-        if (!this.resources.containsKey(id)) {
-            responder.noSuchResource(id);
-            return;
-        }
+            if (!this.resources.containsKey(id)) {
+                responder.noSuchResource(id);
+                return;
+            }
 
-        responder.resourceRead(this.resources.get(id));
+            responder.resourceRead(this.resources.get(id));
+
+        } catch (Throwable t) {
+            responder.internalError(t.getMessage());
+        }
     }
 
     @Override

--- a/modules/container/src/main/java/org/projectodd/restafari/container/ResourceErrorResponse.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/ResourceErrorResponse.java
@@ -13,6 +13,7 @@ public class ResourceErrorResponse extends ResourceResponse {
         READ_NOT_SUPPORTED,
         UPDATE_NOT_SUPPORTED,
         DELETE_NOT_SUPPORTED,
+        INTERNAL_ERROR
     }
 
     public ResourceErrorResponse(ResourceRequest inReplyTo, ErrorType errorType) {

--- a/modules/container/src/main/java/org/projectodd/restafari/container/protocols/http/HttpResourceResponseEncoder.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/protocols/http/HttpResourceResponseEncoder.java
@@ -83,6 +83,10 @@ public class HttpResourceResponseEncoder extends MessageToMessageEncoder<Resourc
                             responseStatusCode = HttpResponseStatus.METHOD_NOT_ALLOWED.code();
                             responseMessage = "Delete not supported";
                             break;
+                        case INTERNAL_ERROR:
+                            responseStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+                            responseMessage = HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase();
+                            break;
                     }
                 }
                 break;
@@ -99,6 +103,13 @@ public class HttpResourceResponseEncoder extends MessageToMessageEncoder<Resourc
             } catch (IncompatibleMediaTypeException e) {
                 e.printStackTrace();
                 responseStatus = new HttpResponseStatus(HttpResponseStatus.NOT_ACCEPTABLE.code(), e.getMessage() );
+                response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus );
+                response.headers().add(HttpHeaders.Names.CONTENT_LENGTH, 0);
+                out.add( response );
+                return;
+            } catch (Throwable e) {
+                e.printStackTrace();
+                responseStatus = new HttpResponseStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase() );
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus );
                 response.headers().add(HttpHeaders.Names.CONTENT_LENGTH, 0);
                 out.add( response );

--- a/modules/container/src/main/java/org/projectodd/restafari/container/responders/BaseResponder.java
+++ b/modules/container/src/main/java/org/projectodd/restafari/container/responders/BaseResponder.java
@@ -71,6 +71,11 @@ public class BaseResponder implements Responder {
         this.ctx.writeAndFlush( new ResourceErrorResponse( this.inReplyTo, ResourceErrorResponse.ErrorType.NO_SUCH_RESOURCE) );
     }
 
+    @Override
+    public void internalError(String message) {
+        this.ctx.writeAndFlush( new ResourceErrorResponse( this.inReplyTo, ResourceErrorResponse.ErrorType.INTERNAL_ERROR) );
+    }
+
     private final ResourceRequest inReplyTo;
     private final ChannelHandlerContext ctx;
 }

--- a/modules/spi/src/main/java/org/projectodd/restafari/spi/resource/async/Responder.java
+++ b/modules/spi/src/main/java/org/projectodd/restafari/spi/resource/async/Responder.java
@@ -66,4 +66,11 @@ public interface Responder {
      */
     void noSuchResource(String id);
 
+    /** Indicate a temporary error condition that normally should not occur during
+     * the processing of this request. Examples include DB unreachable, DB error ...
+     *
+     * @param message
+     */
+    void internalError(String message);
+
 }


### PR DESCRIPTION
Things can go wrong while reading request, and also while fulfilling request - building response. 

The second case wasn't quite covered so a situation like failing to connect to the database resulted in unhandled situation - returning no response to the client.

Would be good to add JSON error responses as well e.g.:

{
    error: {
        code: 1004
        type: java.net.ConnectException
        at: org.projectodd.restafari.mongo.MongoDBResource.readContent(line:97)
        message: Failed to connect to DB
    }
}
