### PR TITLE
JDK 8 build b114 compatibility

### DIFF
--- a/modules/container/src/test/java/org/projectodd/restafari/container/InMemoryCollectionResource.java
+++ b/modules/container/src/test/java/org/projectodd/restafari/container/InMemoryCollectionResource.java
@@ -89,7 +89,7 @@ public class InMemoryCollectionResource implements CollectionResource {
         if (skipPagination) {
             return values.stream();
         }
-        return values.stream().substream(pagination.getOffset()).limit(pagination.getLimit());
+        return values.stream().skip(pagination.getOffset()).limit(pagination.getLimit());
     }
 
     @Override

--- a/modules/mongo/src/main/java/org/projectodd/restafari/mongo/RootMongoResource.java
+++ b/modules/mongo/src/main/java/org/projectodd/restafari/mongo/RootMongoResource.java
@@ -96,7 +96,7 @@ public class RootMongoResource extends MongoResource implements CollectionResour
     @Override
     public void readContent(RequestContext ctx, ResourceSink sink) {
         Pagination pagination = ctx.getPagination();
-        Stream<String> members = this.db.getCollectionNames().stream().substream(pagination.getOffset());
+        Stream<String> members = this.db.getCollectionNames().stream().skip(pagination.getOffset());
         if (pagination.getLimit() > 0) {
             members = members.limit(pagination.getLimit());
         }

--- a/modules/spi/src/main/java/org/projectodd/restafari/spi/resource/sync/SynchronousCollectionResource.java
+++ b/modules/spi/src/main/java/org/projectodd/restafari/spi/resource/sync/SynchronousCollectionResource.java
@@ -38,7 +38,7 @@ public interface SynchronousCollectionResource extends SynchronousResource, Coll
     @Override
     default void readContent(RequestContext ctx, ResourceSink sink) {
         Pagination pagination = ctx.getPagination();
-        Stream<Resource> stream = members().substream( pagination.getOffset() );
+        Stream<Resource> stream = members().skip( pagination.getOffset() );
 
         if ( pagination.getLimit() > 0 ) {
             stream = stream.limit( pagination.getLimit() );


### PR DESCRIPTION
- java.util.stream.Stream substream() is now called skip()
- This patch breaks compatibility with JDK 8 build b106
