### PR TITLE
Updating LiveOak client js

### DIFF
--- a/clients/javascript/src/main/javascript/client.js
+++ b/clients/javascript/src/main/javascript/client.js
@@ -3,49 +3,50 @@
  *
  * Licensed under the Eclipse Public License version 1.0, available at http://www.eclipse.org/legal/epl-v10.html
  */
-var LiveOak = function(host, port, secure, callback) {
-  this._host = host;
-  this._port = port;
-  this._secure = secure;
-  this.stomp_client = new Stomp.Client( host, port, secure );
+/*
+ example:
+ var options = { host: 'http://127.0.0.1', port: 8080 };
+ var liveOak = LiveOak( options );
+*/
+var LiveOak = function( options ) {
+    options = options || {};
 
-}
+    // Allow instantiation without using new
+    if(!this instanceof LiveOak) {
+        return LiveOak( options );
+    }
+    var stomp_client = new Stomp.Client( options.host, options.port, options.secure );
 
-LiveOak.prototype = {
+    this.connect = function( callback ) {
+        stomp_client.connect( callback );
+    };
 
-  connect: function(callback) {
-    this.stomp_client.connect( callback );
-  },
+    this.create = function( path, data, options ) {
+        options = options || {};
+        $.ajax( path, {
+            type: 'POST',
+            data: JSON.stringify( data ),
+            contentType: 'application/json',
+            dataType: 'json',
+            successs: options.success,
+            error: options.error
+        });
+    };
 
-  create: function(path, data) {
-    console.debug( "INSIDE CREATE" );
-    $.ajax( path, {
-      type: "POST",
-      data: JSON.stringify( data ),
-      contentType: 'application/json',
-      dataType: 'json',
-    });
-  },
+    this.read = function( path, options ) {
+        options = options || {};
+        $.ajax( path, {
+            type: 'GET',
+            dataType: 'json',
+            success: options.success,
+            error: options.error
+        });
+    };
 
-  read: function(path, callback) {
-    $.ajax( path, {
-      type: "GET", 
-      dataType: 'json',
-      success: callback,
-    } );
-  },
-
-  update: function(path, data) {
-  },
-
-  delete: function(path) {
-  },
-
-  subscribe: function(path, callback) {
-    this.stomp_client.subscribe( path, function(msg) {
-      var data = JSON.parse( msg.body );
-      callback( data );
-    } );
-  }
-
-}
+    this.subscribe = function( path, callback ) {
+        stomp_client.subscribe( path, function(msg) {
+            var data = JSON.parse( msg.body );
+            callback( data );
+        });
+    };
+};


### PR DESCRIPTION
I've made a few updates to the client.js file
1. For the constructor,  instead of passing in all those variables, you now pass in an "options" object
2. You can now instantiate a LiveOak object without using the new operator
3. the local variables host, port, secure and stomp_client are now "private".  If we need access to them outside of this closure, then we can create some getMethods
4. create and read now have an options parameter that is an object to hold the success and error callbacks
5. i also removed the update and delete functions since they where empty,  i'm sure they will be put back in
