### PR TITLE
Move plugin version declarations to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,23 @@
         <janino.version>2.5.16</janino.version>
         <jgit.version>3.1.0.201310021548-r</jgit.version>
 
-        <!-- checkstyle -->
+        <!-- Maven Plugins -->
+        <version.compiler.plugin>3.1</version.compiler.plugin>
+        <version.source.plugin>2.1.2</version.source.plugin>
+        <version.javadoc.plugin>2.8.1</version.javadoc.plugin>
+        <version.release.plugin>2.4</version.release.plugin>
+        <version.enforcer.plugin>1.3.1</version.enforcer.plugin>
         <version.checkstyle.plugin>2.9.1</version.checkstyle.plugin>
         <version.surefire.plugin>2.16</version.surefire.plugin>
-        <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
         <version.resources.plugin>2.6</version.resources.plugin>
         <version.failsafe.plugin>2.16</version.failsafe.plugin>
+        <version.gpg.plugin>1.4</version.gpg.plugin>
+        <version.resourceStates.plugin>2.4.2</version.resourceStates.plugin>
         <version.vertx.plugin>2.0.1-final</version.vertx.plugin>
         <version.embedmongo.plugin>0.1.10</version.embedmongo.plugin>
+        <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
+        <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
+
     </properties>
     <modules>
         <module>support/build-config</module>
@@ -273,11 +282,94 @@
                 <version>1.0-beta-7</version>
             </extension>
         </extensions>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${version.enforcer.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${version.compiler.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${version.source.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${version.javadoc.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${version.release.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${version.checkstyle.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.resources.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${version.gpg.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${version.failsafe.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resourceStates-plugin</artifactId>
+                    <version>${version.resourceStates.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${version.codehaus.helper.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+                    <artifactId>maven-java-formatter-plugin</artifactId>
+                    <version>${version.google.formatter.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-maven-plugin</artifactId>
+                    <version>${version.vertx.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.joelittlejohn.embedmongo</groupId>
+                    <artifactId>embedmongo-maven-plugin</artifactId>
+                    <version>${version.embedmongo.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -290,18 +382,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.surefire.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${version.surefire.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <pushChanges>false</pushChanges>
                 </configuration>
@@ -309,7 +390,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -319,7 +399,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resourceStates-plugin</artifactId>
-                <version>2.4.2</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -327,7 +406,6 @@
             <plugin>
                 <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
                 <artifactId>maven-java-formatter-plugin</artifactId>
-                <version>0.3.1</version>
                 <configuration>
                     <configFile>${project.basedir}/support/eclipse-formatting.xml</configFile>
                     <lineEnding>LF</lineEnding>
@@ -336,7 +414,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -352,36 +429,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${version.checkstyle.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>${version.resources.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.failsafe.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${version.codehaus.helper.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-maven-plugin</artifactId>
-                <version>${version.vertx.plugin}</version>
-            </plugin>
-            <plugin>
-                <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                <artifactId>embedmongo-maven-plugin</artifactId>
-                <version>${version.embedmongo.plugin}</version>
             </plugin>
         </plugins>
     </build>
@@ -400,7 +447,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.8.1</version>
+                        <version>${version.javadoc.plugin}</version>
                         <configuration>
                             <show>private</show>
                             <nohelp>true</nohelp>
@@ -431,7 +478,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
- increment compiler plugin version to 3.1 for faster compile times
- and enforcer to 1.3.1 - supposed to have some bugs fixed
