### PR TITLE
LIVEOAK-134 Intermittent test failures when building mongo modules

### DIFF
--- a/modules/mongo-gridfs/src/test/java/io/liveoak/mongo/gridfs/BaseGridFSTest.java
+++ b/modules/mongo-gridfs/src/test/java/io/liveoak/mongo/gridfs/BaseGridFSTest.java
@@ -5,18 +5,15 @@
  */
 package io.liveoak.mongo.gridfs;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.DB;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import io.liveoak.common.codec.DefaultResourceState;
-import io.liveoak.mongo.MongoServices;
+import com.mongodb.WriteConcern;
 import io.liveoak.mongo.gridfs.extension.GridFSExtension;
 import io.liveoak.spi.state.ResourceState;
 import io.liveoak.testtools.AbstractResourceTestCase;
 import org.jboss.logging.Logger;
-import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +55,7 @@ public class BaseGridFSTest extends AbstractResourceTestCase {
         try {
             mongoClient = new MongoClient(host, port);
             db = mongoClient.getDB(database);
+            db.setWriteConcern(WriteConcern.ACKNOWLEDGED);
             db.dropDatabase();
         } catch (Exception e) {
             e.printStackTrace();

--- a/modules/mongo/src/main/java/io/liveoak/mongo/MongoBaseObjectResource.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/MongoBaseObjectResource.java
@@ -112,9 +112,9 @@ public class MongoBaseObjectResource extends MongoObjectResource {
                         else {
                             value = createObject( (ResourceState) value );
                         }
-                    }catch (Exception e)  {
+                    } catch (Exception e) {
                         responder.invalidRequest( "Could not update Property");
-                        logger().error("", e);
+                        throw new RuntimeException("Could not update property!", e);
                     }
                 }
                 if (value == null) {
@@ -128,12 +128,11 @@ public class MongoBaseObjectResource extends MongoObjectResource {
                             if (valueDBObject.get( MONGO_ID_FIELD ) != null)
                             {
                                 responder.invalidRequest("Cannot update a DBRef directly");
-                                return;
+                                throw new RuntimeException("Invalid request: Cannot update a DBRef directly!");
                             }
                         }
                     }
-                        dbObject.put(name, value);
-
+                    dbObject.put(name, value);
                 }
             }
         });

--- a/modules/mongo/src/test/java/io/liveoak/mongo/BaseMongoDBTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/BaseMongoDBTest.java
@@ -6,27 +6,21 @@
 
 package io.liveoak.mongo;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
 import com.mongodb.util.JSON;
 import io.liveoak.common.codec.DefaultResourceState;
 import io.liveoak.mongo.extension.MongoExtension;
-import io.liveoak.spi.resource.RootResource;
 import io.liveoak.spi.state.ResourceState;
-import io.liveoak.mongo.extension.MongoExtension;
 import io.liveoak.testtools.AbstractResourceTestCase;
 import org.jboss.logging.Logger;
-import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-
 import java.util.UUID;
 
 /**
@@ -69,6 +63,7 @@ public class BaseMongoDBTest extends AbstractResourceTestCase {
         try {
             mongoClient = new MongoClient(host, port);
             db = mongoClient.getDB(database);
+            db.setWriteConcern(WriteConcern.ACKNOWLEDGED);
             db.dropDatabase();
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
- configure test DB to use WriteConcern.ACKNOWLEDGED
- skip updating an item after responding with Invalid request
