### PR TITLE
LIVEOAK-217 Reduce the default mongo launcher journal size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ npm-debug.log
 .DS_Store
 phantomjsdriver.log
 /launcher/data
-/launcher/conf/extensions/mongoLauncher.json
-/testsuite/src/test/test-configurations/*/conf/extensions/mongoLauncher.json
+/launcher/conf/extensions/mongo-launcher.json
+/testsuite/src/test/test-configurations/*/conf/extensions/mongo-launcher.json
 /testsuite/src/test/test-configurations/*/data

--- a/dist/src/main/resources/assemblies/dist.xml
+++ b/dist/src/main/resources/assemblies/dist.xml
@@ -47,6 +47,9 @@
         <fileSet>
             <directory>../launcher/conf</directory>
             <outputDirectory>/conf</outputDirectory>
+            <excludes>
+                <exclude>extensions/mongo-launcher.json</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>../launcher/apps/admin</directory>

--- a/modules/mongo-launcher/README.md
+++ b/modules/mongo-launcher/README.md
@@ -1,0 +1,85 @@
+Mongo Launcher
+==============
+
+This module contains classes that cover several features:
+
+ - Finding existing MongoDB installation on the system, and installing a new one if none is found (see MongoInstaller.java)
+ - Launching a mongod process to listen on specific port if none is found on that port (see MongoLauncher.java)
+ - Ensuring MongoDB is started before applications depending on it are deployed (see MongoLauncherExtension.java)
+ - Performin autosetup before any LiveOak extensions are started that properly configures and installs MongoLauncherExtension by
+   generating and placing mongo-launcher.json file in $LIVEOAK_HOME/conf/extensions directory (see MongoLauncherAutoSetup.java)
+
+
+Automatic configuration
+-----------------------
+
+When LiveOak is started it automatically scans for presence of MongoDB. If none is found it tries to install one
+using an internet connection. MongoDB instance installed that way is placed in $HOME/.liveoak/mongo directory.
+
+This process is fully automatic, and requires zero interaction.
+
+
+Manual configuration
+--------------------
+
+On first run of LiveOak launcher, $LIVEOAK_HOME/conf/extensions/mongo-launcher.json file is created. This file can be created
+manually beforehand with custom configuration.
+
+Its content looks like:
+
+    {
+      module-id : "io.liveoak.mongo-launcher",
+      config : {
+        enabled : "auto",
+        log-path : "/Users/john/LiveOak/launcher/data/mongod.log",
+        pid-file-path : "/Users/john/LiveOak/launcher/data/mongod.pid",
+        db-path : "/Users/john/LiveOak/launcher/data",
+        use-small-files: true,
+        mongod-path : "/Users/john/.liveoak/mongo/mongodb-osx-x86_64-2.4.9/bin/mongod"
+      }
+    }
+
+The following config option can be used:
+
+### enabled: [auto | true | false]
+
+ This option controls if mongod should be started. The default value is 'auto'.
+
+ If value is 'auto', we first check if existing mongod instance is listening on mongod port. If port accepts connections, then
+ a new mongod instance will not be started.
+
+ Values 'true', and 'false' will be followed blindly - mongod will be started, or there will be no attempt to start it.
+
+### log-path: Path to log file
+
+ This value is passed to mongod as *--logpath* argument.
+
+### pid-file-path: Path to pid file
+
+ This value is passed to mongod as *--pidfilepath* argument.
+
+### db-path: Path to directory containing mongodb data files
+
+ This value is passed to mongod as *--dbpath* argument.
+
+### mongod-path: Path to mongod executable
+
+ If there is existing mongod installation that should be used, this is how to point to it.
+
+### port: Mongod port
+
+ This value is passed to mongod as *--port* argument.
+
+### use-small-files: [true | false]
+
+ This value controls whether mongod is started with *--smallfiles* argument. The default value is true.
+ It is used to reduce disk space usage.
+
+### extra-args: arguments directly passed to mongod
+
+ This value is appended to mongod command line composed from all the previous options.
+
+ Example:
+
+    extra-args : "-vv --maxConns 5"
+

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
@@ -30,6 +30,8 @@ public class MongoLauncher {
     private boolean useAnyMongod;
     private String dbPath;
     private String logPath;
+    private boolean useSmallFiles = true;
+    private StringBuilder extraArgs;
     private OutputStream stdin;
     private Process process;
 
@@ -81,6 +83,25 @@ public class MongoLauncher {
         return useAnyMongod;
     }
 
+    public void setUseSmallFiles(boolean useSmallFiles) {
+        this.useSmallFiles = useSmallFiles;
+    }
+
+    public boolean getUseSmallFiles() {
+        return useSmallFiles;
+    }
+
+    public void addExtraArgs(String extra) {
+        if (extraArgs == null) {
+            extraArgs = new StringBuilder();
+        }
+        extraArgs.append(" ").append(extra);
+    }
+
+    public String getExtraArgs() {
+        return extraArgs.toString();
+    }
+
     public void startMongo() throws IOException {
 
         StringBuilder sb = new StringBuilder();
@@ -109,8 +130,16 @@ public class MongoLauncher {
             sb.append(" --logpath " + logPath);
         }
 
+        if (useSmallFiles) {
+            sb.append(" --smallfiles");
+        }
+
         if (port != 0) {
             sb.append(" --port " + port);
+        }
+
+        if (extraArgs != null) {
+            sb.append(extraArgs);
         }
 
         log.info("Starting mongod: " + sb);

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/Constants.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/Constants.java
@@ -1,0 +1,16 @@
+package io.liveoak.mongo.launcher.config;
+
+/**
+ * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
+ */
+public class Constants {
+    public static final String MONGOD_PATH = "mongod-path";
+    public static final String PORT = "port";
+    public static final String DB_PATH = "db-path";
+    public static final String LOG_PATH = "log-path";
+    public static final String PID_FILE_PATH = "pid-file-path";
+    public static final String USE_ANY_MONGOD = "use-any-mongod";
+    public static final String USE_SMALL_FILES = "use-small-files";
+    public static final String ENABLED = "enabled";
+    public static final String EXTRA_ARGS = "extra-args";
+}

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/MongoLauncherConfigResource.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/MongoLauncherConfigResource.java
@@ -13,6 +13,8 @@ import io.liveoak.spi.resource.async.Responder;
 import io.liveoak.spi.resource.config.ConfigResource;
 import io.liveoak.spi.state.ResourceState;
 
+import static io.liveoak.mongo.launcher.config.Constants.*;
+
 /**
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
@@ -27,7 +29,9 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
     private String dbPath;
     private String logPath;
     private Boolean useAnyMongod = true;
+    private Boolean useSmallFiles = true;
     private String enabled = "auto";
+    private String extraArgs;
 
     public MongoLauncherConfigResource(String id) {
         this.id = id;
@@ -76,35 +80,46 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
         return enabled;
     }
 
+    public boolean useSmallFiles() {
+        return useSmallFiles;
+    }
+
+    public String extraArgs() {
+        return extraArgs;
+    }
+
     @Override
     public void readConfigProperties(RequestContext ctx, PropertySink sink, Resource resource) throws Exception {
-        sink.accept("mongodPath", mongodPath);
-        sink.accept("port", port );
-        sink.accept("dbPath", dbPath);
-        sink.accept("logPath", logPath);
-        sink.accept("pidFilePath", pidFilePath);
-        sink.accept("useAnyMogod", useAnyMongod);
-        sink.accept("enabled", enabled);
+        sink.accept(MONGOD_PATH, mongodPath);
+        sink.accept(PORT, port );
+        sink.accept(DB_PATH, dbPath);
+        sink.accept(LOG_PATH, logPath);
+        sink.accept(PID_FILE_PATH, pidFilePath);
+        sink.accept(USE_ANY_MONGOD, useAnyMongod);
+        sink.accept(USE_SMALL_FILES, useSmallFiles);
+        sink.accept(ENABLED, enabled);
+        sink.accept(EXTRA_ARGS, extraArgs);
     }
 
     @Override
     public void updateConfigProperties(RequestContext ctx, ResourceState state, Responder responder, Resource resource) throws Exception {
-        mongodPath = getStringProperty("mongodPath", state);
-        dbPath = getStringProperty("dbPath", state);
-        logPath = getStringProperty("logPath", state);
-        pidFilePath = getStringProperty("pidFilePath", state);
-        port = getIntegerProperty("port", state);
-        if (port == null) {
-            port = 27017;
-        }
-        useAnyMongod = getBooleanProperty("useAnyMongod", state);
-        if (useAnyMongod == null) {
-            useAnyMongod = true;
-        }
-        enabled = getStringProperty("enabled", state);
-        if (enabled == null) {
-            enabled = "auto";
-        }
+        mongodPath = getStringProperty(MONGOD_PATH, state);
+        dbPath = getStringProperty(DB_PATH, state);
+        logPath = getStringProperty(LOG_PATH, state);
+        pidFilePath = getStringProperty(PID_FILE_PATH, state);
+        extraArgs = getStringProperty(EXTRA_ARGS, state);
+
+        Integer port = getIntegerProperty(PORT, state);
+        this.port = port == null ? 27017 : port;
+
+        Boolean useAnyMongod = getBooleanProperty(USE_ANY_MONGOD, state);
+        this.useAnyMongod = useAnyMongod == null ? true : useAnyMongod;
+
+        Boolean useSmallFiles = getBooleanProperty(USE_SMALL_FILES, state);
+        this.useSmallFiles = useSmallFiles == null ? true : useSmallFiles;
+
+        String enabled = getStringProperty(ENABLED, state);
+        this.enabled = enabled == null ? "auto" : enabled;
     }
 
     // TODO: this should be part of ResourceState probably

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
@@ -64,7 +64,7 @@ public class MongoLauncherService implements Service<MongoLauncher> {
         if (detectRunning) {
             if (serverRunning(port)) {
                 log.warn("It appears there is an existing server on port: " + port);
-                log.warn("Using that one (you can change this behavior via 'enabled' property in conf/extensions/mongoLauncher.json)");
+                log.warn("Not starting mongod (you can change this behavior via 'enabled' property in conf/extensions/mongo-launcher.json)");
                 return;
             }
         }
@@ -89,12 +89,19 @@ public class MongoLauncherService implements Service<MongoLauncher> {
             launcher.setPidFilePath(val);
         }
 
+        launcher.setUseSmallFiles(config.useSmallFiles());
+
+        val = config.extraArgs();
+        if (val != null) {
+            launcher.addExtraArgs(val);
+        }
+
         launcher.setUseAnyMongod(config.useAnyMongod());
 
         try {
             launcher.startMongo();
         } catch (IOException e) {
-            throw new StartException("Failed to start MongoDB - Check mongoLauncher.json extension configuration file", e);
+            throw new StartException("Failed to start MongoDB - Check mongo-launcher.json extension configuration file", e);
         }
     }
 

--- a/modules/mongo-launcher/src/test/java/io/liveoak/mongo/launcher/MongoLauncherTest.java
+++ b/modules/mongo-launcher/src/test/java/io/liveoak/mongo/launcher/MongoLauncherTest.java
@@ -48,6 +48,8 @@ public class MongoLauncherTest extends AbstractTestCase {
         File pidFile = new File(target, "mongod.pid");
         mongo.setPidFilePath(pidFile.getAbsolutePath());
         mongo.setLogPath(new File(target, "mongod.log").getAbsolutePath());
+        mongo.addExtraArgs("-v");
+        mongo.addExtraArgs("--maxConns 5");
         int mongoPort = 27026;
         mongo.setPort(mongoPort);
 


### PR DESCRIPTION
- Also added README
- Did slight refactoring, and applied hyphenated file and JSON key names instead of camel-case
- Renamed mongoLauncher.json to mongo-launcher.json (make sure to remove existing mongoLauncher.json in your conf/extensions)
- Added use-small-files, and extra-args
