### PR TITLE
Fix a few minor MongoLauncher issues

### DIFF
--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoInstaller.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoInstaller.java
@@ -31,7 +31,7 @@ public class MongoInstaller {
 
     private static final String URL_ROOT = "http://fastdl.mongodb.org";
 
-    private String version = "2.4.9";
+    private String version = "2.6.0";
     private String tempDir;
     private String installDir;
     private File mongod;

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
@@ -185,11 +185,20 @@ public class MongoLauncher {
                     }
                     if (nullOrEmpty(result)) {
                         try {
-                            result = OsUtils.execWithOneLiner(new String[] {"sh", "-c", "locate mongod | grep mongod$"}, null, false);
+                            String results = OsUtils.execWithResult(new String[] {"sh", "-c", "locate mongod | grep /mongod$"}, null, false);
+                            for (String line: results.split("\\n")) {
+                                line = line.trim();
+                                // check that file exists since 'locate' is rarely in sync with current affairs
+                                if (new File(line).isFile()) {
+                                    result = line;
+                                    break;
+                                }
+                            }
                         } catch (Exception ignored) {
-                            log.debug("[IGNORED] Command execution failed: sh -c 'locate mongod | grep mongod$'", ignored);
+                            log.debug("[IGNORED] Command execution failed: sh -c 'locate mongod | grep /mongod$'", ignored);
                         }
                     }
+
                 }
             }
 

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncherAutoSetup.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncherAutoSetup.java
@@ -45,7 +45,7 @@ public class MongoLauncherAutoSetup {
             confDir = confDir.getCanonicalFile();
         } catch (IOException ignored) {}
 
-        // locate mongoLauncher.json extension config
+        // locate mongo-launcher.json extension config
         File extDir = new File(confDir, "extensions");
         File launcherJson = new File(extDir, "mongo-launcher.json");
 

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
@@ -46,6 +46,7 @@ public class MongoLauncherService implements Service<MongoLauncher> {
                 break;
             case "true":
                 detectRunning = false;
+                break;
             case "false":
                 log.info("MongoLauncher is explicitly disabled. Not starting mongod automatically");
                 return;
@@ -61,11 +62,13 @@ public class MongoLauncherService implements Service<MongoLauncher> {
             launcher.setPort(port);
         }
 
-        if (detectRunning) {
-            if (serverRunning(port)) {
-                log.warn("It appears there is an existing server on port: " + port);
+        if (serverRunning(port)) {
+            log.warn("It appears there is an existing server on port: " + port);
+            if (detectRunning) {
                 log.warn("Not starting mongod (you can change this behavior via 'enabled' property in conf/extensions/mongo-launcher.json)");
                 return;
+            } else {
+                throw new RuntimeException("Can't start mongod (port already in use)");
             }
         }
 


### PR DESCRIPTION
- Fix use of 'locate': validate each returned path until existing file is found
- Fix handling of 'enabled' config option when value is true
- Bump the default MongoDB version used by MongoInstaller to 2.6.0
