### PR TITLE
LIVEOAK-287 Exception starting up due to wrong version of org.mvel:mvel2 bundled

### DIFF
--- a/modules/3rdparty/src/module/resources/org/drools/main/module.xml
+++ b/modules/3rdparty/src/module/resources/org/drools/main/module.xml
@@ -14,7 +14,7 @@
         <artifact name="org.drools:knowledge-api:${drools.version}"/>
         <artifact name="org.drools:knowledge-internal-api:${drools.version}"/>
         <artifact name="org.codehaus.janino:janino:${janino.version}"/>
-        <artifact name="org.mvel:mvel2:2.1.5.Final"/>
+        <artifact name="org.mvel:mvel2:${mvel.version}"/>
         <artifact name="org.antlr:antlr-runtime:3.3"/>
     </resources>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <mockito.version>1.8.5</mockito.version>
         <fest.version>1.4</fest.version>
         <drools.version>5.6.0.Final</drools.version>
+        <mvel.version>2.1.8.Final</mvel.version>
         <janino.version>2.5.16</janino.version>
         <jgit.version>3.1.0.201310021548-r</jgit.version>
         <javamail.version>1.4.7</javamail.version>
@@ -250,6 +251,11 @@
                 <groupId>org.drools</groupId>
                 <artifactId>drools-templates</artifactId>
                 <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mvel</groupId>
+                <artifactId>mvel2</artifactId>
+                <version>${mvel.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.janino</groupId>


### PR DESCRIPTION
- added explicit dependency
- bumped mvel version to 2.1.8.Final to be the same as current Drools version expects
