### PR TITLE
LIVEOAK-261 Remove autogenerated mongo launcher files from testsuite source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ log
 npm-debug.log
 .DS_Store
 phantomjsdriver.log
-/testsuite/src/test/test-configurations/*/conf/extensions/mongo-launcher.json
-/testsuite/src/test/test-configurations/*/data


### PR DESCRIPTION
- testsuite has been reworked a little, and this issue is no longer present
