### PR TITLE
LIVEOAK-312 Windows firewall alerts during build (tests) on Windows

### DIFF
--- a/modules/keycloak/pom.xml
+++ b/modules/keycloak/pom.xml
@@ -262,35 +262,6 @@
                 <mongo.port>27018</mongo.port>
                 <mongo.host>localhost</mongo.host>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-mongodb</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <port>${mongo.port}</port>
-                                    <logging>file</logging>
-                                    <logFile>${project.build.directory}/mongodb.log</logFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>stop-mongodb</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/modules/mongo-gridfs/pom.xml
+++ b/modules/mongo-gridfs/pom.xml
@@ -41,12 +41,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.joelittlejohn.embedmongo</groupId>
-            <artifactId>embedmongo-maven-plugin</artifactId>
-            <version>0.1.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <scope>provided</scope>
@@ -114,35 +108,6 @@
                 <mongo.port>27018</mongo.port>
                 <mongo.host>localhost</mongo.host>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-mongodb</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <port>${mongo.port}</port>
-                                    <logging>file</logging>
-                                    <logFile>${project.build.directory}/mongodb.log</logFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>stop-mongodb</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/modules/mongo-launcher/pom.xml
+++ b/modules/mongo-launcher/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>liveoak-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.liveoak</groupId>
-            <artifactId>liveoak-test-tools</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <scope>test</scope>

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncherAutoSetup.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncherAutoSetup.java
@@ -15,8 +15,6 @@ import org.jboss.logging.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static io.liveoak.mongo.launcher.MongoLauncher.nullOrEmpty;
 import static io.liveoak.mongo.launcher.config.Constants.DB_PATH;
@@ -100,41 +98,8 @@ public class MongoLauncherAutoSetup {
             }
         }
         if (mongodPath == null) {
-            // if not, set it, let's try to locate existing mongod on the system, and try to execute it
-            String path = MongoLauncher.findMongod();
-            if (nullOrEmpty(path)) {
-                // if no mongod found, launch installer to get it
-                // set path to it in mongo-launcher.json
-                MongoInstaller installer = new MongoInstaller();
-                // use ~/.liveoak/mongo for downloaded archives
-                Path mongoDir = Paths.get(System.getProperty("user.home"), ".liveoak", "mongo");
-                try {
-                    if (!Files.isDirectory(mongoDir)) {
-                        Files.createDirectories(mongoDir);
-                    }
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to create directory: " + mongoDir);
-                }
 
-                installer.setTempDir(mongoDir.toString());
-                installer.setInstallDir(mongoDir.toString());
-                try {
-                    installer.performInstall();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("MongoDB installation failed: ", e);
-                } catch (Throwable t) {
-                    t.printStackTrace();
-                    throw t;
-                }
-
-                // mongo should be installed under mongoDir
-                path = installer.getMongodPath();
-
-                if (nullOrEmpty(path)) {
-                    throw new RuntimeException("Failed to properly install MongoDB");
-                }
-            }
+            String path = MongoInstaller.autoInstall();
 
             // if success set path in mongo-launcher.json
             // determine mongod version

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
@@ -6,8 +6,6 @@
 package io.liveoak.mongo.launcher.service;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 
 import io.liveoak.mongo.launcher.MongoLauncher;
 import io.liveoak.mongo.launcher.config.MongoLauncherConfigResource;
@@ -67,7 +65,7 @@ public class MongoLauncherService implements Service<MongoLauncher> {
                     launcher.setPort(port);
                 }
 
-                if (serverRunning(port)) {
+                if (launcher.serverRunning(port)) {
                     log.warn("It appears there is an existing server on port: " + port);
                     if (exitIfPortTaken) {
                         log.warn("Not starting mongod (you can change this behavior via 'enabled' property in conf/extensions/mongo-launcher.json)");
@@ -110,7 +108,7 @@ public class MongoLauncherService implements Service<MongoLauncher> {
                 try {
                     launcher.startMongo();
 
-                    while(!serverRunning(port)) {
+                    while(!launcher.serverRunning(port)) {
                         try {
                             Thread.sleep(300);
                         } catch (InterruptedException e) {
@@ -130,24 +128,6 @@ public class MongoLauncherService implements Service<MongoLauncher> {
                 context.failed(new StartException(t));
             }
         }, "MongoLauncherService starter").start();
-    }
-
-    private boolean serverRunning(int port) {
-        try {
-            Socket socket = new Socket();
-            socket.connect(new InetSocketAddress("localhost", port), 500);
-            if (socket.isConnected()) {
-                try {
-                    socket.close();
-                } catch (IOException ignored) {
-                    log.debug("[IGNORED] Exception closing server test socket: ", ignored);
-                }
-                return true;
-            }
-        } catch (IOException ignored) {
-            log.debug("[IGNORED] Connection test: ", ignored);
-        }
-        return false;
     }
 
     @Override

--- a/modules/mongo-launcher/src/test/java/io/liveoak/mongo/launcher/MongoLauncherTest.java
+++ b/modules/mongo-launcher/src/test/java/io/liveoak/mongo/launcher/MongoLauncherTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
@@ -12,17 +13,44 @@ import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
 import com.mongodb.WriteResult;
 
-import io.liveoak.testtools.AbstractTestCase;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
-public class MongoLauncherTest extends AbstractTestCase {
+public class MongoLauncherTest {
 
     private static final Logger log = Logger.getLogger(MongoLauncherTest.class);
+
+    protected File projectRoot;
+
+    @Before
+    public void setupUserDir() {
+        String name = getClass().getName().replace(".", "/") + ".class";
+        URL resource = getClass().getClassLoader().getResource(name);
+
+        if (resource != null) {
+            File current = new File(resource.getFile());
+
+            while (current.exists()) {
+                if (current.isDirectory()) {
+                    if (new File(current, "pom.xml").exists()) {
+                        this.projectRoot = current;
+                        break;
+                    }
+                }
+
+                current = current.getParentFile();
+            }
+        }
+
+        if (this.projectRoot != null) {
+            System.setProperty("user.dir", this.projectRoot.getAbsolutePath());
+        }
+    }
 
     @Test
     public void testStartStop() throws IOException {

--- a/modules/mongo/pom.xml
+++ b/modules/mongo/pom.xml
@@ -31,12 +31,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.joelittlejohn.embedmongo</groupId>
-            <artifactId>embedmongo-maven-plugin</artifactId>
-            <version>0.1.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.liveoak</groupId>
             <artifactId>liveoak-test-tools</artifactId>
         </dependency>
@@ -95,35 +89,6 @@
                 <mongo.port>27018</mongo.port>
                 <mongo.host>localhost</mongo.host>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-mongodb</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <port>${mongo.port}</port>
-                                    <logging>file</logging>
-                                    <logFile>${project.build.directory}/mongodb.log</logFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>stop-mongodb</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceCreateTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceCreateTest.java
@@ -9,7 +9,6 @@ package io.liveoak.mongo;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import de.flapdoodle.embed.process.collections.Collections;
 import io.liveoak.common.codec.DefaultResourceState;
 import io.liveoak.spi.RequestContext;
 import io.liveoak.spi.ResourceAlreadyExistsException;
@@ -17,6 +16,7 @@ import io.liveoak.spi.state.ResourceState;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -250,12 +250,12 @@ public class MongoDBResourceCreateTest extends BaseMongoDBTest {
         state.putProperty("foo", "bar");
         state.putProperty("test", 123);
         Object[] arr = { 1, 1, 2, 3, 5, 8, 13, 21 };
-        state.putProperty("arr", Collections.newArrayList(arr));
+        state.putProperty("arr", Arrays.asList(arr));
         state.putProperty("arr2", arr);
 
         ResourceState arrayObj = new DefaultResourceState();
         arrayObj.putProperty("array", "object");
-        ArrayList arrayList = Collections.newArrayList(arr);
+        ArrayList arrayList = new ArrayList(Arrays.asList(arr));
         arrayList.add(arrayObj);
         state.putProperty("arr3", arrayList);
 

--- a/modules/security-aclpolicy/pom.xml
+++ b/modules/security-aclpolicy/pom.xml
@@ -114,35 +114,6 @@
                 <mongo.port>27018</mongo.port>
                 <mongo.host>localhost</mongo.host>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-mongodb</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <port>${mongo.port}</port>
-                                    <logging>file</logging>
-                                    <logFile>${project.build.directory}/mongodb.log</logFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>stop-mongodb</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/modules/security-aclpolicy/src/test/java/io/liveoak/security/policy/acl/AclPolicyTestCase.java
+++ b/modules/security-aclpolicy/src/test/java/io/liveoak/security/policy/acl/AclPolicyTestCase.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.WriteConcern;
@@ -30,6 +29,7 @@ import io.liveoak.spi.ResourceRequest;
 import io.liveoak.spi.ResourceResponse;
 import io.liveoak.spi.resource.async.Resource;
 import io.liveoak.spi.state.ResourceState;
+import io.liveoak.testtools.AbstractTestCase;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,7 +39,7 @@ import org.junit.Test;
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class AclPolicyTestCase {
+public class AclPolicyTestCase extends AbstractTestCase {
 
     private final Logger log = Logger.getLogger(AclPolicyTestCase.class);
 

--- a/modules/ups/pom.xml
+++ b/modules/ups/pom.xml
@@ -105,35 +105,6 @@
                 <mongo.port>27018</mongo.port>
                 <mongo.host>localhost</mongo.host>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-mongodb</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <port>${mongo.port}</port>
-                                    <logging>file</logging>
-                                    <logFile>${project.build.directory}/mongodb.log</logFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>stop-mongodb</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <version.gpg.plugin>1.4</version.gpg.plugin>
         <version.resourceStates.plugin>2.4.2</version.resourceStates.plugin>
         <version.vertx.plugin>2.0.1-final</version.vertx.plugin>
-        <version.embedmongo.plugin>0.1.10</version.embedmongo.plugin>
         <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
         <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
 
@@ -738,11 +737,6 @@
                     <groupId>io.vertx</groupId>
                     <artifactId>vertx-maven-plugin</artifactId>
                     <version>${version.vertx.plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                    <artifactId>embedmongo-maven-plugin</artifactId>
-                    <version>${version.embedmongo.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>httpclient</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.liveoak</groupId>
+            <artifactId>liveoak-mongo-launcher</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
- replaced embedmongo-maven-plugin with MongoLauncher
  - MongoLauncher is triggered if system property mongo.host is set to 'localhost' or '127.0.0.1'
  - system property mongo.port is optional, if not set port will default to 27017
  - triggering logic is in AbstractTestCase, and inherited by all test classes
  - data is stored in module's target/data directory
  - logs are written to module's target/data/mongod.log
