### PR TITLE
Mongo test failures due to missing 'max', 'size' collection properties in some environments

### DIFF
--- a/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBCollectionReadTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBCollectionReadTest.java
@@ -88,7 +88,7 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         for (int i = 0; i < result.members().size(); i++) {
             ResourceState member = result.members().get(i);
             assertThat(member.id()).isEqualTo("collection" + (i + 1));
-            assertThat(member.getPropertyNames().size()).isEqualTo(5);
+
             assertThat(member.getProperty("type")).isEqualTo("collection");
             assertThat(member.members()).isEmpty();
         }
@@ -113,7 +113,7 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
 
         // verify the result
         assertThat(result.id()).isEqualTo(methodName);
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
+
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members()).isEmpty();
 
@@ -147,7 +147,7 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         for (int i = 0; i < result.members().size(); i++) {
             ResourceState member = result.members().get(i);
             assertThat(member.id()).isEqualTo(String.format("collection%1$04d", i + 11));
-            assertThat(member.getPropertyNames().size()).isEqualTo(5);
+
             assertThat(member.getProperty("type")).isEqualTo("collection");
             assertThat(member.members()).isEmpty();
         }
@@ -165,7 +165,7 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         for (int i = 0; i < result.members().size(); i++) {
             ResourceState member = result.members().get(i);
             assertThat(member.id()).isEqualTo(String.format("collection%1$04d", i + 1010));
-            assertThat(member.getPropertyNames().size()).isEqualTo(5);
+
             assertThat(member.getProperty("type")).isEqualTo("collection");
             assertThat(member.members()).isEmpty();
         }
@@ -193,11 +193,12 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         // verify response
         assertThat(result).isNotNull();
         assertThat(result.id()).isEqualTo("testQueryCollection");
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members().size()).isEqualTo(2);
 
+        assertThat(result.members().get(0).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(0).getProperty("name")).isEqualTo("Hans");
+        assertThat(result.members().get(1).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(1).getProperty("name")).isEqualTo("Francois");
 
         // Try another query
@@ -208,11 +209,12 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
 
         assertThat(result).isNotNull();
         assertThat(result.id()).isEqualTo("testQueryCollection");
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members().size()).isEqualTo(2);
 
+        assertThat(result.members().get(0).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(0).getProperty("name")).isEqualTo("John");
+        assertThat(result.members().get(1).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(1).getProperty("name")).isEqualTo("Jane");
     }
 
@@ -237,7 +239,7 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         // verify response
         assertThat(result).isNotNull();
         assertThat(result.id()).isEqualTo("testQueryCollectionNoResults");
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
+
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members().size()).isEqualTo(0);
     }
@@ -293,11 +295,13 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
         // verify response
         assertThat(result).isNotNull();
         assertThat(result.id()).isEqualTo("testQueryCollection");
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
+
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members().size()).isEqualTo(2);
 
+        assertThat(result.members().get(0).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(0).getProperty("name")).isEqualTo("Hans");
+        assertThat(result.members().get(1).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(1).getProperty("name")).isEqualTo("Francois");
 
         // Try another query
@@ -308,11 +312,13 @@ public class MongoDBCollectionReadTest extends BaseMongoDBTest {
 
         assertThat(result).isNotNull();
         assertThat(result.id()).isEqualTo("testQueryCollection");
-        assertThat(result.getPropertyNames().size()).isEqualTo(5);
+
         assertThat(result.getProperty("type")).isEqualTo("collection");
         assertThat(result.members().size()).isEqualTo(2);
 
+        assertThat(result.members().get(0).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(0).getProperty("name")).isEqualTo("John");
+        assertThat(result.members().get(1).getPropertyNames().size()).isEqualTo(5);
         assertThat(result.members().get(1).getProperty("name")).isEqualTo("Jane");
     }
 


### PR DESCRIPTION
- this is probably due to MongoDB version differences
- removed the checks that 'max', and 'size' are always present
