### PR TITLE
LIVEOAK-327: Support specific hosts for the mongo launcher to bind to.

### DIFF
--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/MongoLauncher.java
@@ -28,6 +28,7 @@ public class MongoLauncher {
     private static final Logger mongoLog = Logger.getLogger("mongod");
 
     private String pidFilePath;
+    private String host;
     private int port;
     private String mongodPath;
     private boolean useAnyMongod;
@@ -44,6 +45,14 @@ public class MongoLauncher {
 
     public void setPidFilePath(String pidFilePath) {
         this.pidFilePath = pidFilePath;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
     }
 
     public int getPort() {
@@ -138,6 +147,10 @@ public class MongoLauncher {
 
         if (useSmallFiles) {
             sb.append(" --smallfiles");
+        }
+
+        if (host != null) {
+            sb.append(" --bind_ip " + host);
         }
 
         if (port != 0) {
@@ -273,19 +286,20 @@ public class MongoLauncher {
         if (stdin != null) {
             stdin.close();
         }
+
         if (process != null) {
             process.destroy();
         }
     }
 
-    public static boolean serverRunning(int port) {
-        return serverRunning(port, null);
+    public static boolean serverRunning(String host, int port) {
+        return serverRunning(host, port, null);
     }
 
-    public static boolean serverRunning(int port, Consumer<Throwable> onError) {
+    public static boolean serverRunning(String host, int port, Consumer<Throwable> onError) {
         try {
             Socket socket = new Socket();
-            socket.connect(new InetSocketAddress("localhost", port), 500);
+            socket.connect( new InetSocketAddress( host, port ), 500 );
             if (socket.isConnected()) {
                 try {
                     socket.close();

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/Constants.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/Constants.java
@@ -5,6 +5,7 @@ package io.liveoak.mongo.launcher.config;
  */
 public class Constants {
     public static final String MONGOD_PATH = "mongod-path";
+    public static final String HOST = "host";
     public static final String PORT = "port";
     public static final String DB_PATH = "db-path";
     public static final String LOG_PATH = "log-path";

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/MongoLauncherConfigResource.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/config/MongoLauncherConfigResource.java
@@ -24,6 +24,7 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
     private Resource parent;
 
     private String pidFilePath;
+    private String host = "localhost";
     private Integer port = 27017;
     private String mongodPath;
     private String dbPath;
@@ -54,6 +55,10 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
 
     public String mongodPath() {
         return mongodPath;
+    }
+
+    public String host() {
+        return host;
     }
 
     public int port() {
@@ -91,6 +96,7 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
     @Override
     public void readConfigProperties(RequestContext ctx, PropertySink sink, Resource resource) throws Exception {
         sink.accept(MONGOD_PATH, mongodPath);
+        sink.accept(HOST, host);
         sink.accept(PORT, port );
         sink.accept(DB_PATH, dbPath);
         sink.accept(LOG_PATH, logPath);
@@ -108,6 +114,9 @@ public class MongoLauncherConfigResource implements ConfigResource, RootResource
         logPath = getStringProperty(LOG_PATH, state);
         pidFilePath = getStringProperty(PID_FILE_PATH, state);
         extraArgs = getStringProperty(EXTRA_ARGS, state);
+
+        String host = getStringProperty(HOST, state);
+        this.host = host == null ? "localhost" : host;
 
         Integer port = getIntegerProperty(PORT, state);
         this.port = port == null ? 27017 : port;

--- a/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
+++ b/modules/mongo-launcher/src/main/java/io/liveoak/mongo/launcher/service/MongoLauncherService.java
@@ -60,12 +60,18 @@ public class MongoLauncherService implements Service<MongoLauncher> {
 
         new Thread(() -> {
             try {
+
+                String host = config.host();
+                if (host != null) {
+                    launcher.setHost(host);
+                }
+
                 int port = config.port();
                 if (port != 0) {
                     launcher.setPort(port);
                 }
 
-                if (launcher.serverRunning(port)) {
+                if (launcher.serverRunning(host, port)) {
                     log.warn("It appears there is an existing server on port: " + port);
                     if (exitIfPortTaken) {
                         log.warn("Not starting mongod (you can change this behavior via 'enabled' property in conf/extensions/mongo-launcher.json)");
@@ -108,8 +114,9 @@ public class MongoLauncherService implements Service<MongoLauncher> {
                 try {
                     launcher.startMongo();
 
-                    while(!launcher.serverRunning(port)) {
+                    while(!launcher.serverRunning(host, port)) {
                         try {
+                            log.debug("Attempting to connect to MongoDB instance");
                             Thread.sleep(300);
                         } catch (InterruptedException e) {
                             context.failed(new StartException("Interrupted", e));


### PR DESCRIPTION
Fix race condition in tests when the mongo server tries to start while the previous server is still in the process of shutting down.
