### PR TITLE
LIVEOAK-449: Enhance security pages workflow

### DIFF
--- a/console/src/main/resources/app/partials/security-create.html
+++ b/console/src/main/resources/app/partials/security-create.html
@@ -26,12 +26,29 @@
             <legend lo-collapse class="collapsible"><span class="text">Collection Settings</span></legend>
             <div class="form-group clearfix">
               <label class="col-sm-3 control-label" for="collection">Collection <span class="required">*</span></label>
-              <select lo-select class="col-sm-9" id="collection" ng-options="col.id as col.name for col in collectionsList" ng-model="currentCollection">
-              </select>
+              <div class="dropdown btn-group bootstrap-select col-sm-9" style="z-index: 999;">
+                <button class="btn btn-default col-sm-12" id ="collection" type="button" data-toggle="dropdown">
+                  <span class="pull-left">{{currentCollection}}</span>
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                  <li ng-repeat="col in collectionsList" ng-class="{'active' : col.id===currentCollection}" >
+                    <a role="menuitem" tabindex="-1" ng-click="$parent.currentCollection = col.id">
+                      <span class="text">{{col.id}}</span>
+                    </a>
+                  </li>
+                  <li role="presentation" class="divider"></li>
+                  <li role="presentation">
+                    <a role="menuitem" tabindex="-1" ng-click="modalCollectionAdd()">Add Collection...</a>
+                  </li>
+                </ul>
+              </div>
+              <!--<select lo-select class="col-sm-9" id="collectionX" ng-options="col.id as col.name for col in collectionsList" ng-model="currentCollection">
+              </select>-->
             </div>
             <div class="form-group clearfix">
               <label class="col-sm-3 control-label" for="access">Can access the collection <span class="required">*</span></label>
-              <div class="dropdown btn-group bootstrap-select col-sm-9" style="z-index: 1040;">
+              <div class="dropdown btn-group bootstrap-select col-sm-9" style="z-index: 998;">
                 <button class="btn btn-default dropdown-toggle col-sm-12" id ="access" type="button">
                   <span class="pull-left" ng-show="appRoles.length === 0">The application has no roles</span>
                   <span class="pull-left" ng-show="appRoles.length > 0 && settings.accessRoles.length === 0">Nothing selected</span>

--- a/console/src/main/resources/app/partials/security-list.html
+++ b/console/src/main/resources/app/partials/security-list.html
@@ -19,11 +19,16 @@
         <div class="panel-body text-center empty-instance">
           <i class="fa fa-lock"></i>
 
-          <span ng-hide="unsecuredColls.length > 0">
-            <p>This application has no collections to be secured. Create a collection inside a storage resource first.</p>
+          <span ng-show="storageList.length === 0">
+            <p>This application has no storage resources. Create a storage resource first.</p>
             <a href="#/applications/{{curApp.id}}/storage" class="btn btn-primary btn-lg" type="button">View Storage</a>
           </span>
-          
+
+          <span ng-hide="(storageList.length === 0) || (unsecuredColls.length > 0)">
+            <p>This application has no collections to be secured. Start creating a collection to secure it.</p>
+            <a href="" class="btn btn-primary btn-lg" type="button" ng-click="modalCollectionAdd()">Create Collection</a>
+          </span>
+
           <span ng-show="unsecuredColls.length > 0">
             <p>You have not yet secured any of the collections: <span ng-repeat="c in unsecuredColls"><a href="#/applications/{{curApp.name}}/security/policies/{{c.storage}}/{{c.collection}}">{{c.storage}} / {{c.collection}}</a>{{$last ? '' : ', '}}</span>.</p>
             <a href="#/applications/{{curApp.id}}/security/policies/{{unsecuredColls[0].storage}}/{{unsecuredColls[0].collection}}" class="btn btn-primary btn-lg" type="button">Secure a Collection</a>

--- a/console/src/main/resources/app/templates/modal/security/collection-add.html
+++ b/console/src/main/resources/app/templates/modal/security/collection-add.html
@@ -1,0 +1,51 @@
+<form lo-autofocus name="loCollectionCreate" id="loCollectionCreate" ng-init="setFormScope(this)" novalidate="">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="cancel()">
+      <span class="pficon pficon-close"></span>
+    </button>
+    <h4 class="modal-title">Create New Collection</h4>
+  </div>
+  <div class="modal-body">
+    <div class="form-group clearfix">
+      <label for="collectionName" class="col-sm-3 control-label">Storage Resource</label>
+      <div class="col-sm-7">
+        <!--<select lo-select id="storage" ng-options="storage.id for storage in $parent.$parent.storageList" ng-model="createCollection">
+        </select>-->
+        <div class="dropdown btn-group bootstrap-select" style="margin-bottom: 0;">
+          <button class="btn btn-default col-sm-12" id ="access" type="button" data-toggle="dropdown">
+            <span class="pull-left" ng-hide="collStorage">Select a storage</span>
+            <span class="pull-left" ng-show="collStorage">{{collStorage}}</span>
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" >
+            <li role="presentation" ng-repeat="storage in $parent.$parent.storageList">
+              <a href="" role="menuitem" tabindex="-1" ng-click="$parent.collStorage = storage.id">
+                <span class="text">{{storage.id}}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <span class="help-block ng-hide">
+          <span ng-show="loCollectionCreate.collectionName.$error.required">Collection name is required.</span>
+          <span ng-show="!loCollectionCreate.collectionName.$error.required && loCollectionCreate.collectionName.$error.collectionName">Collection name already exists.</span>
+        </span>
+      </div>
+    </div>
+    <div class="form-group clearfix">
+      <label for="collectionName" class="col-sm-3 control-label">Collection Name</label>
+      <div class="col-sm-7">
+        <input type="text" class="form-control" id="collectionName" name="collectionName" ng-model="collectionName"
+               required autofocus ng-change="checkColName(collectionName)" lo-validation/>
+        <span class="help-block ng-hide">
+          <span ng-show="loCollectionCreate.collectionName.$error.required">Collection name is required.</span>
+          <span ng-show="!loCollectionCreate.collectionName.$error.required && loCollectionCreate.collectionName.$error.collectionName">Collection name already exists.</span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="cancel()">Cancel</button>
+    <button type="submit" class="btn btn-primary" ng-click="collectionCreate(collectionName); close()" ng-disabled="!(collectionName && loCollectionCreate.collectionName.$valid)">Add</button>
+  </div>
+</form>


### PR DESCRIPTION
- Different messages depending on existing storage resource and collections;
- Add ability to add a collection from security policies page when there are storage resources but no collections;
- After successfully adding collection, the user is sent to the page to secure the new collection;
- When securing a collection and a new role is added, it is automatically selected;
- Add ability to add a collection from securing collection screen, selecting it in the dropdown;
