### PR TITLE
RequestForInterest: Support decoding application/x-www-form-urlencoded

### DIFF
--- a/modules/common/src/main/java/io/liveoak/common/codec/form/FormURLDecoder.java
+++ b/modules/common/src/main/java/io/liveoak/common/codec/form/FormURLDecoder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.liveoak.common.codec.form;
+
+import io.liveoak.common.codec.DefaultResourceState;
+import io.liveoak.common.codec.ResourceDecoder;
+import io.liveoak.spi.state.ResourceState;
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Aslak Knutsen
+ */
+public class FormURLDecoder implements ResourceDecoder {
+
+    private static final Charset ENCODING = StandardCharsets.UTF_8;
+
+    @Override
+    public ResourceState decode(ByteBuf resource) throws IOException {
+        return parse(resource);
+    }
+
+    private ResourceState parse(ByteBuf resource) throws IOException {
+        DefaultResourceState state = new DefaultResourceState();
+
+        String content = resource.toString(ENCODING);
+        String[] pairs = content.split("&");
+        if(pairs.length > 0) {
+            for(String pair : pairs) {
+                String[] values = pair.split("=");
+                if(values.length >= 1) {
+                    String name = URLDecoder.decode(values[0], ENCODING.name());
+                    if(values.length == 1) {
+                        if( name.isEmpty() ) {
+                            continue;
+                        }
+                        state.putProperty(name, null);
+                    }
+                    else {
+                        String value = URLDecoder.decode(values[1], ENCODING.name());
+                        Object typed = value;
+                        if("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                            typed = Boolean.parseBoolean(value);
+                        } else if("null".equalsIgnoreCase(value)) {
+                            typed = null;
+                        } else {
+                            try {
+                                typed = Integer.parseInt(value);
+                            } catch(NumberFormatException e) {
+                                try {
+                                    typed = Double.parseDouble(value);
+                                } catch(NumberFormatException e2) {
+                                }
+                            }
+                        }
+                        state.putProperty(name, typed);
+                    }
+                }
+            }
+        }
+        return state;
+    }
+}

--- a/modules/container/src/main/java/io/liveoak/container/service/bootstrap/CodecBootstrappingService.java
+++ b/modules/container/src/main/java/io/liveoak/container/service/bootstrap/CodecBootstrappingService.java
@@ -4,6 +4,7 @@ import io.liveoak.common.codec.ResourceCodec;
 import io.liveoak.common.codec.ResourceCodecManager;
 import io.liveoak.common.codec.ResourceDecoder;
 import io.liveoak.common.codec.StateEncoder;
+import io.liveoak.common.codec.form.FormURLDecoder;
 import io.liveoak.common.codec.html.HTMLEncoder;
 import io.liveoak.common.codec.json.JSONDecoder;
 import io.liveoak.common.codec.json.JSONEncoder;
@@ -11,6 +12,7 @@ import io.liveoak.container.service.CodecInstallationService;
 import io.liveoak.container.service.CodecManagerService;
 import io.liveoak.container.service.CodecService;
 import io.liveoak.spi.MediaType;
+
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -36,6 +38,7 @@ public class CodecBootstrappingService implements Service<Void> {
 
         installCodec(target, MediaType.JSON, JSONEncoder.class, new JSONDecoder());
         installCodec(target, MediaType.HTML, HTMLEncoder.class, null);
+        installCodec(target, MediaType.FORM_URLENCODED, null, new FormURLDecoder());
 
         // Custom Media Types
         installCodec(target, MediaType.LOCAL_APP_JSON, JSONEncoder.class, new JSONDecoder());

--- a/modules/container/src/test/java/io/liveoak/container/codec/form/FormURLDecoderTest.java
+++ b/modules/container/src/test/java/io/liveoak/container/codec/form/FormURLDecoderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.liveoak.container.codec.form;
+
+import io.liveoak.common.codec.form.FormURLDecoder;
+import io.liveoak.spi.state.ResourceState;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Aslak Knutsen
+ */
+public class FormURLDecoderTest {
+
+    protected ResourceState decode(String data) throws Exception {
+
+        FormURLDecoder decoder = new FormURLDecoder();
+        ByteBuf buffer = Unpooled.wrappedBuffer(data.getBytes(Charset.defaultCharset()));
+        return decoder.decode(buffer);
+    }
+
+    @Test
+    public void testEmptyObject() throws Exception {
+        ResourceState state = decode("");
+
+        Assert.assertEquals(0, state.getPropertyNames().size());
+    }
+
+    @Test
+    public void testSingleValue() throws Exception {
+        ResourceState state = decode("a=x");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals("x", state.getProperty("a"));
+    }
+
+    @Test
+    public void testMultipleValues() throws Exception {
+        ResourceState state = decode("a=x&b=y");
+
+        Assert.assertEquals(2, state.getPropertyNames().size());
+        Assert.assertEquals("x", state.getProperty("a"));
+        Assert.assertEquals("y", state.getProperty("b"));
+    }
+
+    @Test
+    public void testEncodedKey() throws Exception {
+        ResourceState state = decode(URLEncoder.encode("a=x", "UTF-8") + "=y");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals("y", state.getProperty("a=x"));
+    }
+
+    @Test
+    public void testEncodedValue() throws Exception {
+        ResourceState state = decode("a=" + URLEncoder.encode("a&b=1", "UTF-8"));
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals("a&b=1", state.getProperty("a"));
+    }
+
+    @Test
+    public void testIntegerTypedValue() throws Exception {
+        ResourceState state = decode("a=1");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Integer);
+        Assert.assertEquals(1, state.getProperty("a"));
+    }
+
+    @Test
+    public void testDoubleTypedValue() throws Exception {
+        ResourceState state = decode("a=1.0");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Double);
+        Assert.assertEquals(1.0, state.getProperty("a"));
+    }
+
+    @Test
+    public void testStringTypedValue() throws Exception {
+        ResourceState state = decode("a=x");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof String);
+        Assert.assertEquals("x", state.getProperty("a"));
+    }
+
+    @Test
+    public void testBooleanTypedTrueUpperValue() throws Exception {
+        ResourceState state = decode("a=TRUE");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Boolean);
+        Assert.assertEquals(true, state.getProperty("a"));
+    }
+
+    @Test
+    public void testBooleanTypedTrueLowerValue() throws Exception {
+        ResourceState state = decode("a=true");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Boolean);
+        Assert.assertEquals(true, state.getProperty("a"));
+    }
+
+    @Test
+    public void testBooleanTypedFalseUpperValue() throws Exception {
+        ResourceState state = decode("a=FALSE");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Boolean);
+        Assert.assertEquals(false, state.getProperty("a"));
+    }
+
+    @Test
+    public void testBooleanTypedFalseLowerValue() throws Exception {
+        ResourceState state = decode("a=false");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertTrue(state.getProperty("a") instanceof Boolean);
+        Assert.assertEquals(false, state.getProperty("a"));
+    }
+
+    @Test
+    public void testNullTypedLowerValue() throws Exception {
+        ResourceState state = decode("a=null");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals(null, state.getProperty("a"));
+    }
+
+    @Test
+    public void testNullTypedUpperValue() throws Exception {
+        ResourceState state = decode("a=NULL");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals(null, state.getProperty("a"));
+    }
+
+    @Test
+    public void testLastOfSameKeyOverrides() throws Exception {
+        ResourceState state = decode("a=x&a=y");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals("y", state.getProperty("a"));
+    }
+
+    @Test
+    public void testProcentEncoding() throws Exception {
+        ResourceState state = decode("a=x%20y");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals("x y", state.getProperty("a"));
+    }
+
+    @Test
+    public void testNullValue() throws Exception {
+        ResourceState state = decode("a=");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals(null, state.getProperty("a"));
+    }
+
+    @Test
+    public void testNullOnKeyOnly() throws Exception {
+        ResourceState state = decode("a");
+
+        Assert.assertEquals(1, state.getPropertyNames().size());
+        Assert.assertEquals(null, state.getProperty("a"));
+    }
+}

--- a/modules/spi/src/main/java/io/liveoak/spi/MediaType.java
+++ b/modules/spi/src/main/java/io/liveoak/spi/MediaType.java
@@ -27,6 +27,7 @@ public class MediaType {
     public static final MediaType LOCAL_APP_JSON = new MediaType("application/liveoak-local-app+json");
 
     public static final MediaType HTML = new MediaType("text/html");
+    public static final MediaType FORM_URLENCODED = new MediaType("application/x-www-form-urlencoded");
     public static final MediaType TEXT = new MediaType("text/plain");
 
     public static final MediaType PNG = new MediaType("image/png");


### PR DESCRIPTION
Support simple www-form-urlencoded message bodies for storage requests.

Message body format:
field=value&field2=value

---

This is not intended to be pulled upstream as is, but rather a pull request to see interest in having it upstream.

I've added a application/x-www-form-urlencoded Decoder to allow using simple html form encoded message bodies directly against the backend storage.

This could be used via HTML e.g.:

``` html
<form method=POST" url="storage/test">
  <input type="text" name="field" value="x" />
  <input type="text" name="field2" value="y" />
</form>
```

Or via command line tools, e.g.:

``` console
curl --request POST http://example.com/app/storage/test --data "field=x&field2=y"
```

If this sounds interesting, I'll clean up/improve some code and do a new request.
