### PR TITLE
Fix test issue with GZIP Compressed response

### DIFF
--- a/test-tools/src/main/java/io/liveoak/testtools/AbstractHTTPResourceTestCase.java
+++ b/test-tools/src/main/java/io/liveoak/testtools/AbstractHTTPResourceTestCase.java
@@ -110,7 +110,7 @@ public abstract class AbstractHTTPResourceTestCase extends AbstractTestCase {
     @Before
     public void setUpClient() throws Exception {
         RequestConfig cconfig = RequestConfig.custom().setSocketTimeout(500000).build();
-        this.httpClient = HttpClients.custom().setDefaultRequestConfig(cconfig).build();
+        this.httpClient = HttpClients.custom().disableContentCompression().setDefaultRequestConfig(cconfig).build();
     }
 
     @After


### PR DESCRIPTION
Apache HTTP Client default add Accept-Encoding: gzip,deflate to
the Request if no Accept-Encoding is given directly.
