### PR TITLE
LIVEOAK-698

### DIFF
--- a/dist/src/main/resources/conf/extensions/mongo-internal.json
+++ b/dist/src/main/resources/conf/extensions/mongo-internal.json
@@ -2,7 +2,6 @@
     module-id:  'io.liveoak.mongo.internal',
     dependencies: ['mongo-launcher', 'mongo'],
     config: {
-      db: "liveoak",
-      datastore: "liveoak"
+      db: "liveoak"
     }
 }

--- a/dist/src/main/resources/conf/extensions/mongo.json
+++ b/dist/src/main/resources/conf/extensions/mongo.json
@@ -2,8 +2,16 @@
     module-id:  'io.liveoak.mongo',
     dependencies: ['mongo-launcher'],
     config: {
-    },
-    instances: {
-      "liveoak" : {}
+       "name" : "Default Datastore",
+       "servers" : [ {
+          "host" : "${liveoak.mongo.host:127.0.0.1}",
+          "port" : "${liveoak.mongo.port:27017}"
+       } ],
+       "credentials" : [ {
+          "username" : "${liveoak.mongo.username:}",
+          "password" : "${liveoak.mongo.password:}",
+          "database" : "${liveoak.mongo.authDb:}",
+          "mechanism" : "MONGODB-CR"
+       } ]    
     }
 }

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/CredentialState.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/CredentialState.java
@@ -30,14 +30,19 @@ public class CredentialState extends EmbeddedConfigResource {
         String mechanism = resourceState.getProperty(MECHANISM, false, String.class);
         String database = resourceState.getProperty(DB, false, String.class);
 
-        MongoCredential credential;
-        if (mechanism.equals(MongoCredential.MONGODB_CR_MECHANISM)) {
-            credential = MongoCredential.createMongoCRCredential(username, database, password.toCharArray());
-        } else {
-            credential = MongoCredential.createGSSAPICredential(username);
-        }
+        if (username != null && !username.isEmpty()) {
 
-        this.mongoCredential = credential;
+            MongoCredential credential;
+            if (mechanism.equals(MongoCredential.MONGODB_CR_MECHANISM)) {
+                credential = MongoCredential.createMongoCRCredential(username, database, password.toCharArray());
+            } else {
+                credential = MongoCredential.createGSSAPICredential(username);
+            }
+
+            this.mongoCredential = credential;
+        } else {
+            this.mongoCredential = null;
+        }
     }
 
     public CredentialState(Resource parent, MongoCredential credential) {

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoreResource.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoreResource.java
@@ -82,7 +82,9 @@ public class MongoDatastoreResource implements RootResource, SynchronousResource
         if (credentials != null) {
             for (ResourceState credential : credentials) {
                 CredentialState cred = new CredentialState(this, credential);
-                mongoCredentials.add(cred.getMongoCredential());
+                if (cred.getMongoCredential() != null) {
+                    mongoCredentials.add(cred.getMongoCredential());
+                }
             }
         }
 

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoreService.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoreService.java
@@ -11,11 +11,11 @@ import org.jboss.msc.value.InjectedValue;
  */
 public class MongoDatastoreService implements Service<MongoDatastoreResource> {
 
-    MongoDatastoreResource resource;
+    MongoSystemDatastoreResource resource;
 
     @Override
     public void start(StartContext context) throws StartException {
-        resource = new MongoDatastoreResource(idInjector.getValue());
+        resource = new MongoSystemDatastoreResource(idInjector.getValue());
 
         mongoDatastoreInjector.getValue().addDataStore(idInjector.getValue(), resource);
     }

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoresRegistry.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoDatastoresRegistry.java
@@ -8,13 +8,13 @@ import java.util.Map;
  */
 public class MongoDatastoresRegistry {
 
-    Map<String, MongoDatastoreResource> datastores = new HashMap<>();
+    Map<String, MongoSystemDatastoreResource> datastores = new HashMap<>();
 
-    public MongoDatastoreResource getDataStore(String name) {
+    public MongoSystemDatastoreResource getDataStore(String name) {
         return datastores.get(name);
     }
 
-    public void addDataStore(String id, MongoDatastoreResource dataStore) {
+    public void addDataStore(String id, MongoSystemDatastoreResource dataStore) {
         datastores.put(id, dataStore);
     }
 }

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoSystemDatastoreResource.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/MongoSystemDatastoreResource.java
@@ -1,0 +1,36 @@
+package io.liveoak.mongo.config;
+
+import java.util.Map;
+
+import io.liveoak.spi.RequestContext;
+import io.liveoak.spi.state.ResourceState;
+
+/**
+ * @author <a href="mailto:mwringe@redhat.com">Matt Wringe</a>
+ */
+public class MongoSystemDatastoreResource extends MongoDatastoreResource {
+
+    //Property key
+    public static final String NAME = "name";
+
+    //
+    private String name;
+
+    public MongoSystemDatastoreResource(String id) {
+        super(id);
+    }
+
+    @Override
+    public Map<String, ?> properties(RequestContext ctx) throws Exception {
+        Map properties = super.properties(ctx);
+        properties.put(NAME, name);
+
+        return properties;
+    }
+
+    @Override
+    public void properties(ResourceState datastorestate) throws Exception {
+        this.name = datastorestate.getProperty(NAME, true, String.class);
+        super.properties(datastorestate);
+    }
+}

--- a/modules/mongo/src/main/java/io/liveoak/mongo/config/ServerAddressState.java
+++ b/modules/mongo/src/main/java/io/liveoak/mongo/config/ServerAddressState.java
@@ -20,7 +20,14 @@ public class ServerAddressState extends EmbeddedConfigResource {
     public ServerAddressState(Resource parent, ResourceState resourceState) throws Exception {
         super(parent);
         String host = resourceState.getProperty(HOST, false, String.class);
-        Integer port = resourceState.getProperty(PORT, false, Integer.class);
+
+        Integer port = resourceState.getProperty(PORT, false, Integer.class, true);
+        if (port == null) {
+            String portString = resourceState.getProperty(PORT, false, String.class, true);
+            if (portString != null) {
+                port = Integer.parseInt(portString);
+            }
+        }
 
         if (port == null) {
             serverAddress = new ServerAddress(host);

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/BaseMongoConfigTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/BaseMongoConfigTest.java
@@ -1,7 +1,8 @@
 package io.liveoak.mongo.config;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.liveoak.common.util.ObjectMapperFactory;
 import io.liveoak.container.tenancy.InternalApplicationExtension;
 import io.liveoak.container.zero.extension.ZeroExtension;
 import io.liveoak.mongo.extension.MongoExtension;
@@ -22,9 +23,11 @@ public abstract class BaseMongoConfigTest extends AbstractTestCaseWithTestApp {
 
     @BeforeClass
     public static void loadExtensions() throws Exception {
-        ObjectNode json = JsonNodeFactory.instance.objectNode();
-        json.put("db", "testDefaultDB");
-        loadExtension("mongo", new MongoExtension(), json);
+        JsonNode configNode = ObjectMapperFactory.create().readTree(
+                "{ name: 'testDefaultDB'," +
+                " servers: []}");
+
+        loadExtension("mongo", new MongoExtension(), (ObjectNode) configNode);
     }
 
     @After

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigClientOptionsTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigClientOptionsTest.java
@@ -1,5 +1,7 @@
 package io.liveoak.mongo.config;
 
+import java.util.ArrayList;
+
 import io.liveoak.common.codec.DefaultResourceState;
 import io.liveoak.spi.RequestContext;
 import io.liveoak.spi.state.ResourceState;
@@ -16,6 +18,7 @@ public class MongoConfigClientOptionsTest extends BaseMongoConfigTest {
     public void defaultTest() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testDefaultDB");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -42,6 +45,7 @@ public class MongoConfigClientOptionsTest extends BaseMongoConfigTest {
     public void configure() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testConfigureDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState mongoClientConfigResourceState = new DefaultResourceState();
         mongoClientConfigResourceState.putProperty(MongoClientOptionsState.DESCRIPTION, "my cool mbaas");
@@ -78,6 +82,7 @@ public class MongoConfigClientOptionsTest extends BaseMongoConfigTest {
     public void updateConfigure() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testUpdateConfigureDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState mongoClientConfigResourceState = new DefaultResourceState();
         mongoClientConfigResourceState.putProperty(MongoClientOptionsState.DESCRIPTION, "my cool mbaas");
@@ -95,6 +100,7 @@ public class MongoConfigClientOptionsTest extends BaseMongoConfigTest {
 
         ResourceState updatedConfig = new DefaultResourceState();
         updatedConfig.putProperty("db", "testUpdateConfigureDB");
+        updatedConfig.putProperty("servers", new ArrayList());
         updatedConfig.putProperty(MongoClientOptionsState.ID, updatedClientConfigResourceState);
 
         ResourceState result = client.update(new RequestContext.Builder().build(), ADMIN_PATH, updatedConfig);

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigCredentialsTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigCredentialsTest.java
@@ -20,6 +20,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
     public void testDefault() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testDefaultDB");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -35,6 +36,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
         ResourceState config = new DefaultResourceState();
         config = new DefaultResourceState();
         config.putProperty("db", "testConfigureCRDB");
+        config.putProperty("servers", new ArrayList());
 
         List<ResourceState> credentials = new ArrayList<>();
         ResourceState credential = new DefaultResourceState();
@@ -66,6 +68,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
         ResourceState config = new DefaultResourceState();
         config = new DefaultResourceState();
         config.putProperty("db", "testConfigureGSSDB");
+        config.putProperty("servers", new ArrayList());
 
         List<ResourceState> credentials = new ArrayList<>();
         ResourceState credential = new DefaultResourceState();
@@ -93,6 +96,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
     public void testConfigureMultipleCredentials () throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "ConfigureMultipleCredentialsDB");
+        config.putProperty("servers", new ArrayList());
 
         List<ResourceState> credentials = new ArrayList<>();
         ResourceState credentialA = new DefaultResourceState();
@@ -147,6 +151,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
     public void testUpdateCredentials() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "UpdateCredentialsDB");
+        config.putProperty("servers", new ArrayList());
 
         List<ResourceState> credentials = new ArrayList<>();
         ResourceState credentialA = new DefaultResourceState();
@@ -176,6 +181,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
 
         ResourceState updatedConfig = new DefaultResourceState();
         updatedConfig.putProperty("db", "UpdateCredentialsDB");
+        updatedConfig.putProperty("servers", new ArrayList());
 
         List<ResourceState> updatedCredentials = new ArrayList<ResourceState>();
 
@@ -200,6 +206,7 @@ public class MongoConfigCredentialsTest extends BaseMongoConfigTest {
     public void testClearCredentials() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testClearCredentials");
+        config.putProperty("servers", new ArrayList());
 
         List<ResourceState> credentials = new ArrayList<>();
         ResourceState credential = new DefaultResourceState();

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigReadPreferenceTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigReadPreferenceTest.java
@@ -1,5 +1,6 @@
 package io.liveoak.mongo.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.liveoak.common.codec.DefaultResourceState;
@@ -21,6 +22,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void readPreference() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testDefaultDB");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -38,6 +40,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void configureType() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testConfigureTypeDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configReadPref = new DefaultResourceState();
         configReadPref.putProperty(ReadPreferenceState.TYPE, "secondary"); // use new string value here, if using ReadPreferenceResource.Types.SECONDARY.toString() then '==' will incorrectly work when we should be using equals()
@@ -61,6 +64,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void updateType() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testUpdateTypeDB");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -77,6 +81,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
 
         config = new DefaultResourceState();
         config.putProperty("db", "testUpdateTypeDB");
+        config.putProperty("servers", new ArrayList());
         config.putProperty(ReadPreferenceState.ID, updatedResourceState);
 
         result = client.update(new RequestContext.Builder().build(), ADMIN_PATH, config);
@@ -88,6 +93,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void setWithTags() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testConfigureWithTagsDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configReadPref = new DefaultResourceState();
         configReadPref.putProperty(ReadPreferenceState.TYPE, ReadPreferenceState.SECONDARY);
@@ -121,6 +127,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void invalidType() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testInvalidTypeDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configReadPref = new DefaultResourceState();
         configReadPref.putProperty(ReadPreferenceState.TYPE, "foobar");
@@ -138,6 +145,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void nullType() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testNullTypeDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configReadPref = new DefaultResourceState();
         configReadPref.putProperty(ReadPreferenceState.TYPE, null);
@@ -161,6 +169,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
     public void updateTags() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testUpdateTagsDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configReadPref = new DefaultResourceState();
         configReadPref.putProperty(ReadPreferenceState.TYPE, ReadPreferenceState.SECONDARY);
@@ -176,6 +185,7 @@ public class MongoConfigReadPreferenceTest extends BaseMongoConfigTest {
 
         ResourceState updatedConfig = new DefaultResourceState();
         updatedConfig.putProperty("db", "testUpdateTagsDB");
+        updatedConfig.putProperty("servers", new ArrayList());
         ResourceState updatedConfigReadPref = new DefaultResourceState();
         updatedConfigReadPref.putProperty(ReadPreferenceState.TYPE, ReadPreferenceState.SECONDARY_PREFERRED);
         ResourceState updatedTagConfig = new DefaultResourceState();

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigWriteConcernTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoConfigWriteConcernTest.java
@@ -1,5 +1,7 @@
 package io.liveoak.mongo.config;
 
+import java.util.ArrayList;
+
 import io.liveoak.common.codec.DefaultResourceState;
 import io.liveoak.spi.RequestContext;
 import io.liveoak.spi.state.ResourceState;
@@ -17,6 +19,7 @@ public class MongoConfigWriteConcernTest extends BaseMongoConfigTest {
     public void testDefault() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testDefaultDB");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -38,6 +41,7 @@ public class MongoConfigWriteConcernTest extends BaseMongoConfigTest {
     public void settingValues() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testDefaultDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configWriteConcernState = new DefaultResourceState();
         configWriteConcernState.putProperty(WriteConcernState.W, 2);
@@ -69,6 +73,7 @@ public class MongoConfigWriteConcernTest extends BaseMongoConfigTest {
     public void taggedWriteConcern() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testTaggedDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configWriteConcernState = new DefaultResourceState();
         configWriteConcernState.putProperty(WriteConcernState.W, "majority");
@@ -100,6 +105,7 @@ public class MongoConfigWriteConcernTest extends BaseMongoConfigTest {
     public void updateWriteConcern() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testUpdateWriteConcernDB");
+        config.putProperty("servers", new ArrayList());
 
         ResourceState configWriteConcernState = new DefaultResourceState();
         configWriteConcernState.putProperty(WriteConcernState.W, 2);
@@ -131,6 +137,7 @@ public class MongoConfigWriteConcernTest extends BaseMongoConfigTest {
     public void nullWriteConcern() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testTaggedDB");
+        config.putProperty("servers", new ArrayList());
 
         config.putProperty(WriteConcernState.ID, null);
 

--- a/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoServersConfigTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/config/MongoServersConfigTest.java
@@ -77,6 +77,7 @@ public class MongoServersConfigTest extends BaseMongoConfigTest {
     public void embeddedResources() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testOnlyDBDatabase");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);
@@ -93,6 +94,7 @@ public class MongoServersConfigTest extends BaseMongoConfigTest {
     public void onlyDb() throws Exception {
         ResourceState config = new DefaultResourceState();
         config.putProperty("db", "testOnlyDBDatabase");
+        config.putProperty("servers", new ArrayList());
         setUpSystem(config);
 
         ResourceState result = client.read(new RequestContext.Builder().build(), ADMIN_PATH);

--- a/openshift/cartridge/src/main/resources/assemblies/openshift.xml
+++ b/openshift/cartridge/src/main/resources/assemblies/openshift.xml
@@ -19,6 +19,7 @@
               <exclude>conf/extensions/keycloak.json</exclude>
               <exclude>apps/admin/application.json</exclude>
               <exclude>conf/extensions/mongo-launcher.json</exclude>
+              <exclude>conf/extensions/https-redirect.json</exclude>
             </excludes>
         </fileSet>
         <fileSet>

--- a/openshift/cartridge/src/main/resources/openshift/versions/conf/extensions/https-redirect.json
+++ b/openshift/cartridge/src/main/resources/openshift/versions/conf/extensions/https-redirect.json
@@ -1,0 +1,10 @@
+{
+    module-id:  'io.liveoak.redirect.https',
+    config: {
+      default: {
+        redirects: 'SECURED',
+        redirect-type: 'TEMPORARY',
+        max-age: 300
+      }
+    }
+}


### PR DESCRIPTION
Default to using the system level shared datasource when no mongo configuration given.
Add support for named datasources instead of relying on an id only.
Update the https-redirect defaults for openshfit.
