### PR TITLE
LIVEOAK-697

### DIFF
--- a/console/src/main/resources/app/js/controllers/application.js
+++ b/console/src/main/resources/app/js/controllers/application.js
@@ -200,9 +200,7 @@ loMod.controller('AppListCtrl', function($scope, $rootScope, $routeParams, $loca
                   id: $scope.storagePath,
                   type: 'mongo',
                   config: {
-                    db: $scope.appModel.id,
-                    servers: [{host: 'localhost', port: 27017}],
-                    credentials: []
+                    db: $scope.appModel.id
                   }
                 };
 
@@ -332,7 +330,7 @@ loMod.controller('NextStepsCtrl', function($scope, $rootScope, $routeParams, cur
   /* jshint unused: false */
   angular.forEach(loStorageList.members, function (value, key) {
     if (value.hasOwnProperty('db')) {
-      this.push({id: value.id, provider: value.hasOwnProperty('MongoClientOptions') ? 'mongoDB' : 'unknown', port: value.servers[0].port || '?'});
+      this.push({id: value.id, provider: value.hasOwnProperty('MongoClientOptions') ? 'mongoDB' : 'unknown'});
     }
     else if(value.hasOwnProperty('upsURL')) {
       $scope.pushConfig = value;

--- a/console/src/main/resources/app/partials/next-steps.html
+++ b/console/src/main/resources/app/partials/next-steps.html
@@ -21,10 +21,6 @@
               <span class="lo-label">URL Path:</span>
               <span class="lo-field">/{{storage.id}}</span>
             </div>
-            <div>
-              <span class="lo-label">Port:</span>
-              <span class="lo-field">{{storage.port}}</span>
-            </div>
           </div>
           <p class="content-area" ng-hide="storageList.length > 0">Store your application's data in the cloud</p>
           <ul class="actions" ng-show="storageList.length > 0">


### PR DESCRIPTION
Remove the host, port and credentials for mongo when creating a new application. This will cause the application to use the system default datastore instead.
