### PR TITLE
LIVEOAK-648

### DIFF
--- a/modules/common/src/main/java/io/liveoak/common/codec/driver/StateEncodingDriver.java
+++ b/modules/common/src/main/java/io/liveoak/common/codec/driver/StateEncodingDriver.java
@@ -106,11 +106,11 @@ public class StateEncodingDriver extends AbstractEncodingDriver {
 
     protected void encodeState(ResourceState resourceState, ReturnFields returnFields) throws Exception {
 
-        if (returnFields.excluded("id")) {
+        if (returnFields.excluded(LiveOak.ID)) {
             resourceState.id(null);
         }
 
-        if (returnFields.excluded("self")) {
+        if (returnFields.excluded(LiveOak.SELF)) {
             resourceState.uri(null);
         }
 

--- a/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceReadTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceReadTest.java
@@ -78,7 +78,7 @@ public class MongoDBResourceReadTest extends BaseMongoDBTest {
         // create the object using the mongo driver directly
         BasicDBObject object = new BasicDBObject();
         object.append("foo", "bar");
-        object.append("child", new BasicDBObject().append("ABC", "XYZ"));
+        object.append("child", new BasicDBObject().append("ABC", "XYZ").append("id", "child"));
         db.getCollection(methodName).insert(object);
         assertEquals(1, db.getCollection(methodName).getCount());
         String id = "ObjectId(\"" + object.getObjectId("_id").toString() + "\")";
@@ -90,6 +90,8 @@ public class MongoDBResourceReadTest extends BaseMongoDBTest {
         assertThat(result.getProperty("foo")).isEqualTo("bar");
         ResourceState resultChild = (ResourceState) result.getProperty("child");
         assertThat(resultChild.getProperty("ABC")).isEqualTo("XYZ");
+        assertThat(resultChild.getProperty("id")).isEqualTo("child");
+        assertThat(resultChild.getProperty("_id")).isNull();
     }
 
     @Test

--- a/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceUpdateTest.java
+++ b/modules/mongo/src/test/java/io/liveoak/mongo/MongoDBResourceUpdateTest.java
@@ -55,6 +55,77 @@ public class MongoDBResourceUpdateTest extends BaseMongoDBTest {
     }
 
     @Test
+    public void embeddedUpdate() throws Exception {
+        String methodName = "testEmebeddedUpdate";
+        assertThat(db.getCollection(methodName).getCount()).isEqualTo(0);
+
+        //create the object using the mongo driver directly
+        BasicDBObject object = new BasicDBObject();
+        object.append("_id", "parent");
+        object.append("test", 123);
+
+        BasicDBObject child = new BasicDBObject();
+        child.append("id", "foo");
+        child.append("test", "123");
+
+        BasicDBObject gChild = new BasicDBObject();
+        gChild.append("id", "bar");
+        gChild.append("testing", "one-two-three");
+
+        child.append("bar", gChild);
+        object.append("foo", child);
+
+        db.getCollection(methodName).insert(object);
+        assertEquals(1, db.getCollection(methodName).getCount());
+
+        // update the resource using the client.update method
+        ResourceState state = client.read(new RequestContext.Builder().build(), "/testApp/" + BASEPATH + "/" + methodName + "/parent");
+        state.removeProperty("test");
+
+        ResourceState fooState = state.getProperty("foo", true, ResourceState.class);
+        fooState.putProperty("test", 123);
+
+        ResourceState barState = fooState.getProperty("bar", true, ResourceState.class);
+        barState.putProperty("id", "baz");
+        barState.putProperty("testing", "1-2-3");
+
+        ResourceState updatedState = client.update(new RequestContext.Builder().build(), "/testApp/" + BASEPATH + "/" + methodName + "/parent", state);
+
+        assertThat(updatedState.id()).isEqualTo("parent");
+        assertThat(updatedState.getPropertyNames().size()).isEqualTo(1);
+
+        ResourceState updatedFoo = updatedState.getProperty("foo", true, ResourceState.class);
+        assertThat(updatedFoo.id()).isNull();
+        assertThat(updatedFoo.getProperty("id")).isEqualTo("foo");
+        assertThat(updatedFoo.getProperty("test")).isEqualTo(123);
+
+        ResourceState updatedBar = updatedFoo.getProperty("bar", true, ResourceState.class);
+        assertThat(updatedBar.id()).isNull();
+        assertThat(updatedBar.getProperty("id")).isEqualTo("baz");
+        assertThat(updatedBar.getProperty("testing")).isEqualTo("1-2-3");
+
+        // verify db content
+        assertThat(db.getCollection(methodName).getCount()).isEqualTo(1);
+        DBObject dbObject = db.getCollection(methodName).findOne();
+        assertThat(dbObject.get("_id")).isEqualTo("parent");
+        assertThat(dbObject.keySet().size()).isEqualTo(2);
+
+        DBObject fooObject = (DBObject) dbObject.get("foo");
+        assertThat(fooObject).isNotNull();
+        assertThat(fooObject.keySet().size()).isEqualTo(3);
+        assertThat(fooObject.get("_id")).isNull();
+        assertThat(fooObject.get("id")).isEqualTo("foo");
+        assertThat(fooObject.get("test")).isEqualTo(123);
+
+        DBObject barObject = (DBObject) fooObject.get("bar");
+        assertThat(barObject).isNotNull();
+        assertThat(barObject.keySet().size()).isEqualTo(2);
+        assertThat(barObject.get("_id")).isNull();
+        assertThat(barObject.get("id")).isEqualTo("baz");
+        assertThat(barObject.get("testing")).isEqualTo("1-2-3");
+    }
+
+    @Test
     public void childDirectUpdate() throws Exception {
         String methodName = "testChildDirectUpdate";
         assertThat(db.getCollection(methodName).getCount()).isEqualTo(0);


### PR DESCRIPTION
Fix issue where an 'id' property in an embedded mongo resource would be converted to "_id"